### PR TITLE
Allow skip inventory related objects

### DIFF
--- a/changelogs/fragments/filetree_create_allow_skip_inventory_related_objects.yml
+++ b/changelogs/fragments/filetree_create_allow_skip_inventory_related_objects.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+      - filetree_create is able to export inventory without sources/hosts/groups.
+...

--- a/changelogs/fragments/filetree_create_double_quotes_issue.yaml
+++ b/changelogs/fragments/filetree_create_double_quotes_issue.yaml
@@ -1,3 +1,4 @@
+---
 bugfixes:
   - filetree_create job_template double quote issue
 ...

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -27,6 +27,9 @@ The following variables are required for that role to work properly:
 | `organization`| N/A | no | str | Default organization for all objects that have not been set in the source controller.|
 | `export_related_objects` | False | no | bool | Whether to export related objects (job templates related to certain workflows and the projects associated with these job templates) when a single JT or a single WFJT are being exported. |
 | `update_project_state` | False | no | bool | Whether the project should be updated after import to the target controller. |
+| `skip_inventory_sources` | False | no | bool | Whether the inventory sources should be exported with inventory. |
+| `skip_inventory_hosts` | False | no | bool | Whether the inventory hosts should be exported with inventory. |
+| `skip_inventory_groups` | False | no | bool | Whether the inventory groups should be exported with inventory. |
 
 ## Dependencies
 

--- a/roles/filetree_create/defaults/main.yml
+++ b/roles/filetree_create/defaults/main.yml
@@ -23,7 +23,9 @@ output_path: "/tmp/filetree_output"
 # Maximum number of objects to return from the list. If a list view returns more an max_objects an exception will be raised
 query_controller_api_max_objects: 10000
 export_related_objects: false
-
+skip_inventory_sources: false
+skip_inventory_hosts: false
+skip_inventory_groups: false
 controller_configuration_filetree_create_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 
 input_tag:

--- a/roles/filetree_create/tasks/inventory.yml
+++ b/roles/filetree_create/tasks/inventory.yml
@@ -87,71 +87,80 @@
         loop_var: current_inventories_asset_value
         label: "{{ __dest }}"
 
-- name: "Set the inventory's inventory sources"
-  ansible.builtin.include_tasks: "inventory_sources.yml"
-  when: current_inventory_sources.total_inventory_sources > 0
-  vars:
-    inventory_organization: "{{ current_inventory_sources.summary_fields.organization.name | default(organization) }}"
-    inventory_name: "{{ current_inventory_sources.name | regex_replace('/', '_') }}"
-    inventory_sources_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/inventories/' + inventory_name | regex_replace('/', '_'))
-                                       if (flatten_output is not defined or (flatten_output | bool) == false)
-                                       else
-                                         output_path + '/inventory_sources.yaml' }}"
-    current_inventory_sources_asset_value: "{{ query(controller_api_plugin, current_inventory_sources.related.inventory_sources,
-                                                     host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
-                                                     return_all=true, max_objects=query_controller_api_max_objects)
-                                               if current_inventory_sources.has_inventory_sources else []
-                                            }}"
-    last_inventory: "{{ current_inventory_index == ((inventory_lookvar | length) - 1) }}"
-  loop: "{{ inventory_lookvar }}"
-  loop_control:
-    index_var: current_inventory_index
-    loop_var: current_inventory_sources
-    label: "{{ inventory_sources_output_path }}"
-  no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
+- name: "Skip inventory sources"
+  when: not skip_inventory_sources
+  block:
+    - name: "Set the inventory's inventory sources"
+      ansible.builtin.include_tasks: "inventory_sources.yml"
+      when: current_inventory_sources.total_inventory_sources > 0
+      vars:
+        inventory_organization: "{{ current_inventory_sources.summary_fields.organization.name | default(organization) }}"
+        inventory_name: "{{ current_inventory_sources.name | regex_replace('/', '_') }}"
+        inventory_sources_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/inventories/' + inventory_name | regex_replace('/', '_'))
+                                          if (flatten_output is not defined or (flatten_output | bool) == false)
+                                          else
+                                            output_path + '/inventory_sources.yaml' }}"
+        current_inventory_sources_asset_value: "{{ query(controller_api_plugin, current_inventory_sources.related.inventory_sources,
+                                                        host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
+                                                        return_all=true, max_objects=query_controller_api_max_objects)
+                                                  if current_inventory_sources.has_inventory_sources else []
+                                                }}"
+        last_inventory: "{{ current_inventory_index == ((inventory_lookvar | length) - 1) }}"
+      loop: "{{ inventory_lookvar }}"
+      loop_control:
+        index_var: current_inventory_index
+        loop_var: current_inventory_sources
+        label: "{{ inventory_sources_output_path }}"
+      no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
-- name: "Set the inventory's hosts"
-  ansible.builtin.include_tasks: "hosts.yml"
-  vars:
-    inventory_organization: "{{ current_inventory_hosts.summary_fields.organization.name | default(organization) }}"
-    inventory_name: "{{ current_inventory_hosts.name | regex_replace('/', '_') }}"
-    hosts_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/inventories/' + inventory_name | regex_replace('/', '_'))
-                           if (flatten_output is not defined or (flatten_output | bool) == false)
-                           else
-                             output_path + '/hosts.yaml' }}"
-    current_hosts_asset_value: "{{ query(controller_api_plugin, current_inventory_hosts.related.hosts,
-                                         query_params={'not__description': 'imported'},
-                                         host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
-                                         return_all=true, max_objects=query_controller_api_max_objects)
-                                   if not current_inventory_hosts.has_inventory_sources else []
-                                }}"
-  loop: "{{ inventory_lookvar }}"
-  loop_control:
-    index_var: current_inventory_index
-    loop_var: current_inventory_hosts
-    label: "{{ hosts_output_path }}"
-  no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
+- name: "Skip inventory hosts"
+  when: not skip_inventory_hosts
+  block:
+    - name: "Set the inventory's hosts"
+      ansible.builtin.include_tasks: "hosts.yml"
+      vars:
+        inventory_organization: "{{ current_inventory_hosts.summary_fields.organization.name | default(organization) }}"
+        inventory_name: "{{ current_inventory_hosts.name | regex_replace('/', '_') }}"
+        hosts_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/inventories/' + inventory_name | regex_replace('/', '_'))
+                              if (flatten_output is not defined or (flatten_output | bool) == false)
+                              else
+                                output_path + '/hosts.yaml' }}"
+        current_hosts_asset_value: "{{ query(controller_api_plugin, current_inventory_hosts.related.hosts,
+                                            query_params={'not__description': 'imported'},
+                                            host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
+                                            return_all=true, max_objects=query_controller_api_max_objects)
+                                      if not current_inventory_hosts.has_inventory_sources else []
+                                    }}"
+      loop: "{{ inventory_lookvar }}"
+      loop_control:
+        index_var: current_inventory_index
+        loop_var: current_inventory_hosts
+        label: "{{ hosts_output_path }}"
+      no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
-- name: "Set the inventory's groups"
-  ansible.builtin.include_tasks: "groups.yml"
-  when: current_inventory_groups.total_groups > 0
-  vars:
-    inventory_organization: "{{ current_inventory_groups.summary_fields.organization.name | default(organization) }}"
-    inventory_name: "{{ current_inventory_groups.name | regex_replace('/', '_') }}"
-    groups_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/inventories/' + inventory_name | regex_replace('/', '_'))
-                           if (flatten_output is not defined or (flatten_output | bool) == false)
-                           else
-                             output_path + '/groups.yaml' }}"
-    current_groups_asset_value: "{{ query(controller_api_plugin, current_inventory_groups.related.groups,
-                                          query_params={'not__description': 'imported'},
-                                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
-                                          return_all=true, max_objects=query_controller_api_max_objects)
-                                    if (not current_inventory_groups.has_inventory_sources or current_inventory_groups.kind is match('smart')) else []
-                                 }}"
-  loop: "{{ inventory_lookvar }}"
-  loop_control:
-    index_var: current_inventory_index
-    loop_var: current_inventory_groups
-    label: "{{ groups_output_path }}"
-  no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
+- name: "Skip inventory groups"
+  when: not skip_inventory_groups
+  block:
+    - name: "Set the inventory's groups"
+      ansible.builtin.include_tasks: "groups.yml"
+      when: current_inventory_groups.total_groups > 0
+      vars:
+        inventory_organization: "{{ current_inventory_groups.summary_fields.organization.name | default(organization) }}"
+        inventory_name: "{{ current_inventory_groups.name | regex_replace('/', '_') }}"
+        groups_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/inventories/' + inventory_name | regex_replace('/', '_'))
+                              if (flatten_output is not defined or (flatten_output | bool) == false)
+                              else
+                                output_path + '/groups.yaml' }}"
+        current_groups_asset_value: "{{ query(controller_api_plugin, current_inventory_groups.related.groups,
+                                              query_params={'not__description': 'imported'},
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
+                                              return_all=true, max_objects=query_controller_api_max_objects)
+                                        if (not current_inventory_groups.has_inventory_sources or current_inventory_groups.kind is match('smart')) else []
+                                    }}"
+      loop: "{{ inventory_lookvar }}"
+      loop_control:
+        index_var: current_inventory_index
+        loop_var: current_inventory_groups
+        label: "{{ groups_output_path }}"
+      no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 ...

--- a/roles/filetree_create/tasks/inventory.yml
+++ b/roles/filetree_create/tasks/inventory.yml
@@ -88,80 +88,72 @@
         loop_var: current_inventories_asset_value
         label: "{{ __dest }}"
 
-- name: "Skip inventory sources"
-  when: not skip_inventory_sources
-  block:
-    - name: "Set the inventory's inventory sources"
-      ansible.builtin.include_tasks: "inventory_sources.yml"
-      when: current_inventory_sources.total_inventory_sources > 0
-      vars:
-        inventory_organization: "{{ current_inventory_sources.summary_fields.organization.name | default(organization) }}"
-        inventory_name: "{{ current_inventory_sources.name | regex_replace('/', '_') }}"
-        inventory_sources_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/inventories/' + inventory_name | regex_replace('/', '_'))
-                                          if (flatten_output is not defined or (flatten_output | bool) == false)
-                                          else
-                                            output_path + '/inventory_sources.yaml' }}"
-        current_inventory_sources_asset_value: "{{ query(controller_api_plugin, current_inventory_sources.related.inventory_sources,
-                                                        host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
-                                                        return_all=true, max_objects=query_controller_api_max_objects)
-                                                  if current_inventory_sources.has_inventory_sources else []
-                                                }}"
-        last_inventory: "{{ current_inventory_index == ((inventory_lookvar | length) - 1) }}"
-      loop: "{{ inventory_lookvar }}"
-      loop_control:
-        index_var: current_inventory_index
-        loop_var: current_inventory_sources
-        label: "{{ inventory_sources_output_path }}"
-      no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
+- name: "Set the inventory's inventory sources"
+  ansible.builtin.include_tasks: "inventory_sources.yml"
+  when: current_inventory_sources.total_inventory_sources > 0 and not skip_inventory_sources
+  vars:
+    inventory_organization: "{{ current_inventory_sources.summary_fields.organization.name | default(organization) }}"
+    inventory_name: "{{ current_inventory_sources.name | regex_replace('/', '_') }}"
+    inventory_sources_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/inventories/' + inventory_name | regex_replace('/', '_'))
+                                      if (flatten_output is not defined or (flatten_output | bool) == false)
+                                      else
+                                        output_path + '/inventory_sources.yaml' }}"
+    current_inventory_sources_asset_value: "{{ query(controller_api_plugin, current_inventory_sources.related.inventory_sources,
+                                                    host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
+                                                    return_all=true, max_objects=query_controller_api_max_objects)
+                                              if current_inventory_sources.has_inventory_sources else []
+                                            }}"
+    last_inventory: "{{ current_inventory_index == ((inventory_lookvar | length) - 1) }}"
+  loop: "{{ inventory_lookvar }}"
+  loop_control:
+    index_var: current_inventory_index
+    loop_var: current_inventory_sources
+    label: "{{ inventory_sources_output_path }}"
+  no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
-- name: "Skip inventory hosts"
+- name: "Set the inventory's hosts"
+  ansible.builtin.include_tasks: "hosts.yml"
   when: not skip_inventory_hosts
-  block:
-    - name: "Set the inventory's hosts"
-      ansible.builtin.include_tasks: "hosts.yml"
-      vars:
-        inventory_organization: "{{ current_inventory_hosts.summary_fields.organization.name | default(organization) }}"
-        inventory_name: "{{ current_inventory_hosts.name | regex_replace('/', '_') }}"
-        hosts_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/inventories/' + inventory_name | regex_replace('/', '_'))
-                              if (flatten_output is not defined or (flatten_output | bool) == false)
-                              else
-                                output_path + '/hosts.yaml' }}"
-        current_hosts_asset_value: "{{ query(controller_api_plugin, current_inventory_hosts.related.hosts,
-                                            query_params={'not__description': 'imported'},
-                                            host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
-                                            return_all=true, max_objects=query_controller_api_max_objects)
-                                      if not current_inventory_hosts.has_inventory_sources else []
-                                    }}"
-      loop: "{{ inventory_lookvar }}"
-      loop_control:
-        index_var: current_inventory_index
-        loop_var: current_inventory_hosts
-        label: "{{ hosts_output_path }}"
-      no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
+  vars:
+    inventory_organization: "{{ current_inventory_hosts.summary_fields.organization.name | default(organization) }}"
+    inventory_name: "{{ current_inventory_hosts.name | regex_replace('/', '_') }}"
+    hosts_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/inventories/' + inventory_name | regex_replace('/', '_'))
+                          if (flatten_output is not defined or (flatten_output | bool) == false)
+                          else
+                            output_path + '/hosts.yaml' }}"
+    current_hosts_asset_value: "{{ query(controller_api_plugin, current_inventory_hosts.related.hosts,
+                                        query_params={'not__description': 'imported'},
+                                        host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
+                                        return_all=true, max_objects=query_controller_api_max_objects)
+                                  if not current_inventory_hosts.has_inventory_sources else []
+                                }}"
+  loop: "{{ inventory_lookvar }}"
+  loop_control:
+    index_var: current_inventory_index
+    loop_var: current_inventory_hosts
+    label: "{{ hosts_output_path }}"
+  no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
-- name: "Skip inventory groups"
-  when: not skip_inventory_groups
-  block:
-    - name: "Set the inventory's groups"
-      ansible.builtin.include_tasks: "groups.yml"
-      when: current_inventory_groups.total_groups > 0
-      vars:
-        inventory_organization: "{{ current_inventory_groups.summary_fields.organization.name | default(organization) }}"
-        inventory_name: "{{ current_inventory_groups.name | regex_replace('/', '_') }}"
-        groups_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/inventories/' + inventory_name | regex_replace('/', '_'))
-                              if (flatten_output is not defined or (flatten_output | bool) == false)
-                              else
-                                output_path + '/groups.yaml' }}"
-        current_groups_asset_value: "{{ query(controller_api_plugin, current_inventory_groups.related.groups,
-                                              query_params={'not__description': 'imported'},
-                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
-                                              return_all=true, max_objects=query_controller_api_max_objects)
-                                        if (not current_inventory_groups.has_inventory_sources or current_inventory_groups.kind is match('smart')) else []
-                                    }}"
-      loop: "{{ inventory_lookvar }}"
-      loop_control:
-        index_var: current_inventory_index
-        loop_var: current_inventory_groups
-        label: "{{ groups_output_path }}"
-      no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
+- name: "Set the inventory's groups"
+  ansible.builtin.include_tasks: "groups.yml"
+  when: current_inventory_groups.total_groups > 0 and not skip_inventory_groups
+  vars:
+    inventory_organization: "{{ current_inventory_groups.summary_fields.organization.name | default(organization) }}"
+    inventory_name: "{{ current_inventory_groups.name | regex_replace('/', '_') }}"
+    groups_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/inventories/' + inventory_name | regex_replace('/', '_'))
+                          if (flatten_output is not defined or (flatten_output | bool) == false)
+                          else
+                            output_path + '/groups.yaml' }}"
+    current_groups_asset_value: "{{ query(controller_api_plugin, current_inventory_groups.related.groups,
+                                          query_params={'not__description': 'imported'},
+                                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
+                                          return_all=true, max_objects=query_controller_api_max_objects)
+                                    if (not current_inventory_groups.has_inventory_sources or current_inventory_groups.kind is match('smart')) else []
+                                }}"
+  loop: "{{ inventory_lookvar }}"
+  loop_control:
+    index_var: current_inventory_index
+    loop_var: current_inventory_groups
+    label: "{{ groups_output_path }}"
+  no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
I've noticed that currently, exporting an inventory includes everything related to it, but sometimes this isn't necessary — for example, when exporting the smart inventory without hosts. That's why I'm proposing this change. Default behaviour stay the same.

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
Cosmetic change, won't need a tests.


# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

# Other Relevant info, PRs, etc
N/A