### PR TITLE
fix issue with exporting roles

### DIFF
--- a/changelogs/fragments/filetree_create_role_issue.yml
+++ b/changelogs/fragments/filetree_create_role_issue.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - filetree_create roles export issue
+...

--- a/roles/filetree_create/tasks/team_roles.yml
+++ b/roles/filetree_create/tasks/team_roles.yml
@@ -19,18 +19,15 @@
     - name: "Match objects with roles"
       when: (team_roles_lookvar | selectattr('name','equalto', item.0) | selectattr('summary_fields.resource_type','equalto', item.1) | map(attribute='summary_fields.resource_name')) | length > 0
       ansible.builtin.set_fact:
-        object_roles: >-
-          {{ object_roles +
-            [{ item.0:
-              {
-                'resource_names': (team_roles_lookvar |
-                                  selectattr('name','equalto', item.0) |
-                                  selectattr('summary_fields.resource_type','equalto', item.1) |
-                                  map(attribute='summary_fields.resource_name')),
-                'resource_type': item.1,
-              }
-            }]
-          }}"
+        object_roles: "{{ object_roles + [{ item.0:
+                                                    {
+                                                      'resource_names': (team_roles_lookvar | selectattr('name','equalto', item.0) |
+                                                                         selectattr('summary_fields.resource_type','equalto', item.1) |
+                                                                         map(attribute='summary_fields.resource_name')),
+                                                      'resource_type': item.1,
+                                                    }
+                                         }]
+                      }}"
       loop: "{{ role_types | product(object_types) | list }}"
 
 - name: "Block for to generate flatten output"

--- a/roles/filetree_create/tasks/user_roles.yml
+++ b/roles/filetree_create/tasks/user_roles.yml
@@ -23,18 +23,15 @@
     - name: "Match objects with roles"
       when: (user_roles_lookvar | selectattr('name','equalto', item.0) | selectattr('summary_fields.resource_type', 'defined') | selectattr('summary_fields.resource_type','equalto', item.1) | map(attribute='summary_fields.resource_name')) | length > 0
       ansible.builtin.set_fact:
-        object_roles: >-
-          {{ object_roles +
-            [{ item.0:
-              {
-                'resource_names': (user_roles_lookvar |
-                                   selectattr('name','equalto', item.0) |
-                                   selectattr('summary_fields.resource_type','equalto', item.1) |
-                                   map(attribute='summary_fields.resource_name')),
-                'resource_type': item.1,
-              }
-            }]
-          }}
+        object_roles: "{{ object_roles + [{ item.0:
+                                                    {
+                                                      'resource_names': (user_roles_lookvar | selectattr('name','equalto', item.0) |
+                                                                        selectattr('summary_fields.resource_type','equalto', item.1) |
+                                                                        map(attribute='summary_fields.resource_name')),
+                                                      'resource_type': item.1,
+                                                    }
+                                         }]
+                      }}"
       loop: "{{ role_types | product(object_types) | list }}"
 
 - name: "Block for to generate flatten output"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Hi, recently I've notice that export roles require minor fix due to bug in the code.

While exporting the roles there is an error:
```bash
Unexpected templating type error occurred
```
# How should this be tested?
Export teams/users with roles and there should be no error.

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

# Other Relevant info, PRs, etc
N/A