### PR TITLE
fix extra_vars regex issue

### DIFF
--- a/changelogs/fragments/filetree_create_extra_vars_issue.yml
+++ b/changelogs/fragments/filetree_create_extra_vars_issue.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - filetree_create extra_vars regex issue
+...

--- a/roles/filetree_create/templates/current_job_templates.j2
+++ b/roles/filetree_create/templates/current_job_templates.j2
@@ -130,7 +130,7 @@ controller_templates:
          | default(current_job_templates_asset_value.extra_vars)
          | from_yaml | to_nice_yaml(indent=2)
          | indent(width=6, first=False)
-         | regex_replace('(^[^:]*): (.*){{', '\1: !unsafe \2{{', multiline=True)
+         | regex_replace('(^[^:]*): (.*){{', '\\g<1>: !unsafe \\g<2>{{', multiline=True)
       }}
 {%- endif %}
     job_tags: "{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].job_tags

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -65,7 +65,7 @@ controller_workflows:
       {{ template_overrides_resources.workflow_job_template[current_workflow_job_templates_asset_value.name].extra_vars
          | default(template_overrides_global.workflow_template.extra_vars)
          | default(current_workflow_job_templates_asset_value.extra_vars)
-         | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | regex_replace('(^[^:]*): (.*){{', '\1: !unsafe \2{{', multiline=True) }}
+         | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | regex_replace('(^[^:]*): (.*){{', '\\g<1>: !unsafe \\g<2>{{', multiline=True) }}
 {%- endif %}
 {% if query_labels | length > 0 %}
     labels:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Today I've discovered that regex related to `extra_vars` is not working properly.

View from GitHub UI:
![Screenshot 2024-10-31 at 11 42 45](https://github.com/user-attachments/assets/3eb62218-ba69-49da-b5cc-784440af117c)

View from VIM:
![Screenshot 2024-10-31 at 11 42 26](https://github.com/user-attachments/assets/771bbfae-cbe8-4333-8f64-7321f1fba038)

And PR is fixing this.

# How should this be tested?
Export the job template or workflow with extra_vars that need `!unsafe`.

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

# Other Relevant info, PRs, etc
N/A