### PR TITLE
remove extra ')' character

### DIFF
--- a/roles/filetree_create/templates/controller_job_templates.j2
+++ b/roles/filetree_create/templates/controller_job_templates.j2
@@ -196,7 +196,7 @@ controller_templates:
                                               host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs)[0])
                               | from_yaml | to_nice_yaml(indent=2,width=500,sort_keys=False) | regex_replace("\n\n[ ]*", "\\\\n")
                               | indent(width=6, first=False) | regex_replace('(^[^:]*): (.*){([{%])', '\\g<1>: !unsafe \\g<2>{\\g<3>', multiline=True)
-                              | replace("^$", "") | replace("$encrypted$", "\'\'"))
+                              | replace("^$", "") | replace("$encrypted$", "\'\'")
 -%}
 {% if template_overrides_resources.job_template[current_job_templates_asset_value.name].survey_spec is defined
       or template_overrides_global.job_template.survey_spec is defined


### PR DESCRIPTION
removing extra character from controller_job_templates.j2 that caused the export to fail

<!--- markdownlint-disable MD041 -->
# What does this PR do?
Removing a character that caused the export failures in job templates

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
not that I could find

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->


```
TASK [infra.aap_configuration_extended.filetree_create : Add current job_templates to the controller_job_templates flat file] ***************************************************************
task path: /home/kupo/.ansible/collections/ansible_collections/infra/aap_configuration_extended/roles/filetree_create/tasks/controller_job_templates.yml:42
exception during Jinja2 execution: Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/ansible/template/__init__.py", line 975, in do_template
    t = myenv.from_string(data)
        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/jinja2/environment.py", line 1108, in from_string
    return cls.from_code(self, self.compile(source), gs, None)
                               ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/jinja2/environment.py", line 768, in compile
    self.handle_exception(source=source_hint)
  File "/usr/lib/python3.12/site-packages/jinja2/environment.py", line 939, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "<unknown>", line 199, in template
jinja2.exceptions.TemplateSyntaxError: unexpected ')'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/ansible/template/__init__.py", line 873, in _lookup
    ran = instance.run(loop_terms, variables=self._available_variables, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/ansible/plugins/lookup/template.py", line 160, in run
    res = templar.template(template_data, preserve_trailing_newlines=True,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/ansible/template/__init__.py", line 764, in template
    result = self.do_template(
             ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/ansible/template/__init__.py", line 977, in do_template
    raise AnsibleError("template error while templating string: %s. String: %s" % (to_native(e), to_native(data)), orig_exc=e)
ansible.errors.AnsibleError: template error while templating string: unexpected ')'. String: {% if (current_job_template_index | default(0)) == 0 %}
---
controller_templates:
{% endif %}
  - name: "{{ current_job_templates_asset_value.name }}"
    description: "{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].description
                     | default(template_overrides_global.job_template.description)
                     | default(current_job_templates_asset_value.description)
    }}"
    organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | default(organization if organization != 'ORGANIZATIONLESS' else 'ToDo: The job template \'' + current_job_templates_asset_value.name + '\' must belong to an organization') }}"
    project: "{{ current_job_templates_asset_value.summary_fields.project.name | default('ToDo: The job template \'' + current_job_templates_asset_value.name + '\' must have a project assigned') }}"
{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].inventory is defined
      or template_overrides_global.job_template.inventory is defined
      or current_job_templates_asset_value.inventory %}
    inventory: "{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].inventory
                   | default(template_overrides_global.job_template.inventory)
                   | default(current_job_templates_asset_value.summary_fields.inventory.name) }}"
{% endif %}
    playbook: "{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].playbook
                  | default(template_overrides_global.job_template.playbook)
                  | default(current_job_templates_asset_value.playbook) }}"
    scm_branch: "{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].scm_branch
                  | default(template_overrides_global.job_template.scm_branch)
                  | default(current_job_templates_asset_value.scm_branch) }}"
    forks: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].forks
                  | default(template_overrides_global.job_template.forks)
                  | default(current_job_templates_asset_value.forks) }}
    limit: "{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].limit
                  | default(template_overrides_global.job_template.limit)
                  | default(current_job_templates_asset_value.limit) }}"
    verbosity: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].verbosity
                  | default(template_overrides_global.job_template.verbosity)
                  | default(current_job_templates_asset_value.verbosity) }}
    job_type: "{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].job_type
                  | default(template_overrides_global.job_template.job_type)
                  | default(current_job_templates_asset_value.job_type) }}"
    job_slice_count: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].job_slice_count
                  | default(template_overrides_global.job_template.job_slice_count)
                  | default(current_job_templates_asset_value.job_slice_count) }}
    use_fact_cache: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].use_fact_cache
                  | default(template_overrides_global.job_template.use_fact_cache)
                  | default(current_job_templates_asset_value.use_fact_cache | bool | lower) }}
{% if current_job_templates_asset_value.summary_fields.credentials %}
    credentials:
{% for credential in current_job_templates_asset_value.summary_fields.credentials %}
      - "{{ credential.name }}"
{% endfor %}
{% endif %}
    allow_simultaneous: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].allow_simultaneous
                           | default(template_overrides_global.job_template.allow_simultaneous)
                           | default(current_job_templates_asset_value.allow_simultaneous | bool | lower) }}
    ask_scm_branch_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_scm_branch_on_launch
                                 | default(template_overrides_global.job_template.ask_scm_branch_on_launch)
                                 | default(current_job_templates_asset_value.ask_scm_branch_on_launch | bool | lower) }}
    ask_diff_mode_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_diff_mode_on_launch
                                | default(template_overrides_global.job_template.ask_diff_mode_on_launch)
                                | default(current_job_templates_asset_value.ask_diff_mode_on_launch | bool | lower) }}
    ask_tags_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_tags_on_launch
                           | default(template_overrides_global.job_template.ask_tags_on_launch)
                           | default(current_job_templates_asset_value.ask_tags_on_launch | bool | lower) }}
    ask_skip_tags_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_skip_tags_on_launch
                                | default(template_overrides_global.job_template.ask_skip_tags_on_launch)
                                | default(current_job_templates_asset_value.ask_skip_tags_on_launch | bool | lower) }}
    ask_job_type_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_job_type_on_launch
                               | default(template_overrides_global.job_template.ask_job_type_on_launch)
                               | default(current_job_templates_asset_value.ask_job_type_on_launch | bool | lower) }}
    ask_verbosity_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_verbosity_on_launch
                                | default(template_overrides_global.job_template.ask_verbosity_on_launch)
                                | default(current_job_templates_asset_value.ask_verbosity_on_launch | bool | lower) }}
    ask_variables_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_variables_on_launch
                                | default(template_overrides_global.job_template.ask_variables_on_launch)
                                | default(current_job_templates_asset_value.ask_variables_on_launch | bool | lower) }}
    ask_inventory_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_inventory_on_launch
                                | default(template_overrides_global.job_template.ask_inventory_on_launch)
                                | default(current_job_templates_asset_value.ask_inventory_on_launch | bool | lower) }}
    ask_limit_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_limit_on_launch
                            | default(template_overrides_global.job_template.ask_limit_on_launch)
                            | default(current_job_templates_asset_value.ask_limit_on_launch | bool | lower) }}
    ask_credential_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_credential_on_launch
                                 | default(template_overrides_global.job_template.ask_credential_on_launch)
                                 | default(current_job_templates_asset_value.ask_credential_on_launch | bool | lower) }}
{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_execution_environment_on_launch is defined
      or template_overrides_global.job_template.ask_execution_environment_on_launch is defined
      or current_job_templates_asset_value.ask_execution_environment_on_launch is defined %}
    ask_execution_environment_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_execution_environment_on_launch
                                            | default(template_overrides_global.job_template.ask_execution_environment_on_launch)
                                            | default(current_job_templates_asset_value.ask_execution_environment_on_launch | bool | lower) }}
{% endif %}
{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_labels_on_launch is defined
      or template_overrides_global.job_template.ask_labels_on_launch is defined
      or current_job_templates_asset_value.ask_labels_on_launch is defined %}
    ask_labels_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_labels_on_launch
                             | default(template_overrides_global.job_template.ask_labels_on_launch)
                             | default(current_job_templates_asset_value.ask_labels_on_launch | bool | lower) }}
{% endif %}
{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_forks_on_launch is defined
      or template_overrides_global.job_template.ask_forks_on_launch is defined
      or current_job_templates_asset_value.ask_forks_on_launch is defined %}
    ask_forks_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_forks_on_launch
                            | default(template_overrides_global.job_template.ask_forks_on_launch)
                            | default(current_job_templates_asset_value.ask_forks_on_launch | bool | lower) }}
{% endif %}
{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_job_slice_count_on_launch is defined
      or template_overrides_global.job_template.ask_job_slice_count_on_launch is defined
      or current_job_templates_asset_value.ask_job_slice_count_on_launch is defined %}
    ask_job_slice_count_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_job_slice_count_on_launch
                                      | default(template_overrides_global.job_template.ask_job_slice_count_on_launch)
                                      | default(current_job_templates_asset_value.ask_job_slice_count_on_launch | bool | lower) }}
{% endif %}
{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_timeout_on_launch is defined
      or template_overrides_global.job_template.ask_timeout_on_launch is defined
      or current_job_templates_asset_value.ask_timeout_on_launch is defined %}
    ask_timeout_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_timeout_on_launch
                              | default(template_overrides_global.job_template.ask_timeout_on_launch)
                              | default(current_job_templates_asset_value.ask_timeout_on_launch | bool | lower) }}
{% endif %}
{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_instance_groups_on_launch is defined
      or template_overrides_global.job_template.ask_instance_groups_on_launch is defined
      or current_job_templates_asset_value.ask_instance_groups_on_launch is defined %}
    ask_instance_groups_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_instance_groups_on_launch
                                      | default(template_overrides_global.job_template.ask_instance_groups_on_launch)
                                      | default(current_job_templates_asset_value.ask_instance_groups_on_launch | bool | lower) }}
{% endif %}
{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].extra_vars is defined
      or template_overrides_global.job_template.extra_vars is defined
      or current_job_templates_asset_value.extra_vars and current_job_templates_asset_value.extra_vars | length > 3 %}
    extra_vars:
      {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].extra_vars
         | default(template_overrides_global.job_template.extra_vars)
         | default(current_job_templates_asset_value.extra_vars)
         | from_yaml | to_nice_yaml(indent=2, sort_keys=False)
         | indent(width=6, first=False)
         | regex_replace('(^[^:]*): (.*){([{%])', '\\g<1>: !unsafe \\g<2>{\\g<3>', multiline=True)
      }}
{%- endif %}
    job_tags: "{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].job_tags
                  | default(template_overrides_global.job_template.job_tags)
                  | default(current_job_templates_asset_value.job_tags) }}"
    force_handlers: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].force_handlers
                       | default(template_overrides_global.job_template.force_handlers)
                       | default(current_job_templates_asset_value.force_handlers | bool | lower) }}
    skip_tags: "{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].skip_tags
                   | default(template_overrides_global.job_template.skip_tags)
                   | default(current_job_templates_asset_value.skip_tags) }}"
    start_at_task: "{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].start_at_task
                       | default(template_overrides_global.job_template.start_at_task)
                       | default(current_job_templates_asset_value.start_at_task) }}"
    timeout: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].timeout
                | default(template_overrides_global.job_template.timeout)
                | default(current_job_templates_asset_value.timeout | int) }}
{% if is_aap and (template_overrides_resources.job_template[current_job_templates_asset_value.name].execution_environment is defined
                  or template_overrides_global.job_template.execution_environment is defined
                  or current_job_templates_asset_value.summary_fields.execution_environment is defined) %}
    execution_environment: "{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].execution_environment
                               | default(template_overrides_global.job_template.execution_environment)
                               | default(current_job_templates_asset_value.summary_fields.execution_environment.name) }}"
{% endif %}
{% if not is_aap %}
    custom_virtualenv: "{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].custom_virtualenv
                           | default(template_overrides_global.job_template.custom_virtualenv)
                           | default(current_job_templates_asset_value.custom_virtualenv | default(omit)) }}"
{% endif %}
    host_config_key: "{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].host_config_key
                         | default(template_overrides_global.job_template.host_config_key)
                         | default(current_job_templates_asset_value.host_config_key) }}"
{% if query_labels | length > 0 %}
    labels:
{% for label in query_labels %}
      - "{{ label.name }}"
{% endfor %}
{% endif %}
{% if query_notification_error | length > 0 %}
    notification_templates_error:
{% for notification_error  in query_notification_error %}
      - "{{ notification_error.name }}"
{% endfor %}
{% endif %}
{% if query_notification_started | length > 0 %}
    notification_templates_started:
{% for notification_started  in query_notification_started %}
      - "{{ notification_started.name }}"
{% endfor %}
{% endif %}
{% if query_notification_success | length > 0 %}
    notification_templates_success:
{% for notification_success  in query_notification_success %}
      - "{{ notification_success.name }}"
{% endfor %}
{% endif %}
    survey_enabled: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].survey_enabled
                       | default(template_overrides_global.job_template.survey_enabled)
                       | default(current_job_templates_asset_value.survey_enabled | bool | lower) }}
{% set survey_spec_contents = template_overrides_resources.job_template[current_job_templates_asset_value.name].survey_spec
                              | default(template_overrides_global.job_template.survey_spec)
                              | default(query(controller_api_plugin, current_job_templates_asset_value.related.survey_spec,
                                              host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs)[0])
                              | from_yaml | to_nice_yaml(indent=2,width=500,sort_keys=False) | regex_replace("\n\n[ ]*", "\\\\n")
                              | indent(width=6, first=False) | regex_replace('(^[^:]*): (.*){([{%])', '\\g<1>: !unsafe \\g<2>{\\g<3>', multiline=True)
                              | replace("^$", "") | replace("$encrypted$", "\'\'"))
-%}
{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].survey_spec is defined
      or template_overrides_global.job_template.survey_spec is defined
      or (current_job_templates_asset_value.related.survey_spec is defined and survey_spec_contents | length > 3) %}
    survey_spec:
      {{ survey_spec_contents }}
{% endif %}
    become_enabled: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].become_enabled
                       | default(template_overrides_global.job_template.become_enabled)
                       | default(current_job_templates_asset_value.become_enabled | bool | lower) }}
    diff_mode: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].diff_mode
                       | default(template_overrides_global.job_template.diff_mode)
                       | default(current_job_templates_asset_value.diff_mode | bool | lower) }}
    webhook_service: "{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].webhook_service
                       | default(template_overrides_global.job_template.webhook_service)
                       | default(current_job_templates_asset_value.webhook_service) }}"
{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].webhook_credential is defined
      or template_overrides_global.job_template.webhook_credential is defined
      or current_job_templates_asset_value.webhook_credential %}
    webhook_credential: "{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].webhook_credential
                            | default(template_overrides_global.job_template.webhook_credential)
                            | default(current_job_templates_asset_value.webhook_credential) }}"
{% endif %}
{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].prevent_instance_group_fallback is defined
      or template_overrides_global.job_template.prevent_instance_group_fallback is defined
      or current_job_templates_asset_value.prevent_instance_group_fallback is defined %}
    prevent_instance_group_fallback: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].prevent_instance_group_fallback
                                        | default(template_overrides_global.job_template.prevent_instance_group_fallback)
                                        | default(current_job_templates_asset_value.prevent_instance_group_fallback | bool | lower) }}
{% endif %}
{% if last_job_template | default(true) | bool | lower %}
...
{% endif %}
. unexpected ')'
fatal: [localhost]: FAILED! => {
    "msg": "An unhandled exception occurred while running the lookup plugin 'template'. Error was a <class 'ansible.errors.AnsibleError'>, original message: template error while templating string: unexpected ')'. String: {% if (current_job_template_index | default(0)) == 0 %}\n---\ncontroller_templates:\n{% endif %}\n  - name: \"{{ current_job_templates_asset_value.name }}\"\n    description: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].description\n                     | default(template_overrides_global.job_template.description)\n                     | default(current_job_templates_asset_value.description)\n    }}\"\n    organization: \"{{ current_job_templates_asset_value.summary_fields.organization.name | default(organization if organization != 'ORGANIZATIONLESS' else 'ToDo: The job template \\'' + current_job_templates_asset_value.name + '\\' must belong to an organization') }}\"\n    project: \"{{ current_job_templates_asset_value.summary_fields.project.name | default('ToDo: The job template \\'' + current_job_templates_asset_value.name + '\\' must have a project assigned') }}\"\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].inventory is defined\n      or template_overrides_global.job_template.inventory is defined\n      or current_job_templates_asset_value.inventory %}\n    inventory: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].inventory\n                   | default(template_overrides_global.job_template.inventory)\n                   | default(current_job_templates_asset_value.summary_fields.inventory.name) }}\"\n{% endif %}\n    playbook: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].playbook\n                  | default(template_overrides_global.job_template.playbook)\n                  | default(current_job_templates_asset_value.playbook) }}\"\n    scm_branch: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].scm_branch\n                  | default(template_overrides_global.job_template.scm_branch)\n                  | default(current_job_templates_asset_value.scm_branch) }}\"\n    forks: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].forks\n                  | default(template_overrides_global.job_template.forks)\n                  | default(current_job_templates_asset_value.forks) }}\n    limit: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].limit\n                  | default(template_overrides_global.job_template.limit)\n                  | default(current_job_templates_asset_value.limit) }}\"\n    verbosity: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].verbosity\n                  | default(template_overrides_global.job_template.verbosity)\n                  | default(current_job_templates_asset_value.verbosity) }}\n    job_type: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].job_type\n                  | default(template_overrides_global.job_template.job_type)\n                  | default(current_job_templates_asset_value.job_type) }}\"\n    job_slice_count: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].job_slice_count\n                  | default(template_overrides_global.job_template.job_slice_count)\n                  | default(current_job_templates_asset_value.job_slice_count) }}\n    use_fact_cache: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].use_fact_cache\n                  | default(template_overrides_global.job_template.use_fact_cache)\n                  | default(current_job_templates_asset_value.use_fact_cache | bool | lower) }}\n{% if current_job_templates_asset_value.summary_fields.credentials %}\n    credentials:\n{% for credential in current_job_templates_asset_value.summary_fields.credentials %}\n      - \"{{ credential.name }}\"\n{% endfor %}\n{% endif %}\n    allow_simultaneous: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].allow_simultaneous\n                           | default(template_overrides_global.job_template.allow_simultaneous)\n                           | default(current_job_templates_asset_value.allow_simultaneous | bool | lower) }}\n    ask_scm_branch_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_scm_branch_on_launch\n                                 | default(template_overrides_global.job_template.ask_scm_branch_on_launch)\n                                 | default(current_job_templates_asset_value.ask_scm_branch_on_launch | bool | lower) }}\n    ask_diff_mode_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_diff_mode_on_launch\n                                | default(template_overrides_global.job_template.ask_diff_mode_on_launch)\n                                | default(current_job_templates_asset_value.ask_diff_mode_on_launch | bool | lower) }}\n    ask_tags_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_tags_on_launch\n                           | default(template_overrides_global.job_template.ask_tags_on_launch)\n                           | default(current_job_templates_asset_value.ask_tags_on_launch | bool | lower) }}\n    ask_skip_tags_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_skip_tags_on_launch\n                                | default(template_overrides_global.job_template.ask_skip_tags_on_launch)\n                                | default(current_job_templates_asset_value.ask_skip_tags_on_launch | bool | lower) }}\n    ask_job_type_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_job_type_on_launch\n                               | default(template_overrides_global.job_template.ask_job_type_on_launch)\n                               | default(current_job_templates_asset_value.ask_job_type_on_launch | bool | lower) }}\n    ask_verbosity_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_verbosity_on_launch\n                                | default(template_overrides_global.job_template.ask_verbosity_on_launch)\n                                | default(current_job_templates_asset_value.ask_verbosity_on_launch | bool | lower) }}\n    ask_variables_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_variables_on_launch\n                                | default(template_overrides_global.job_template.ask_variables_on_launch)\n                                | default(current_job_templates_asset_value.ask_variables_on_launch | bool | lower) }}\n    ask_inventory_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_inventory_on_launch\n                                | default(template_overrides_global.job_template.ask_inventory_on_launch)\n                                | default(current_job_templates_asset_value.ask_inventory_on_launch | bool | lower) }}\n    ask_limit_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_limit_on_launch\n                            | default(template_overrides_global.job_template.ask_limit_on_launch)\n                            | default(current_job_templates_asset_value.ask_limit_on_launch | bool | lower) }}\n    ask_credential_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_credential_on_launch\n                                 | default(template_overrides_global.job_template.ask_credential_on_launch)\n                                 | default(current_job_templates_asset_value.ask_credential_on_launch | bool | lower) }}\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_execution_environment_on_launch is defined\n      or template_overrides_global.job_template.ask_execution_environment_on_launch is defined\n      or current_job_templates_asset_value.ask_execution_environment_on_launch is defined %}\n    ask_execution_environment_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_execution_environment_on_launch\n                                            | default(template_overrides_global.job_template.ask_execution_environment_on_launch)\n                                            | default(current_job_templates_asset_value.ask_execution_environment_on_launch | bool | lower) }}\n{% endif %}\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_labels_on_launch is defined\n      or template_overrides_global.job_template.ask_labels_on_launch is defined\n      or current_job_templates_asset_value.ask_labels_on_launch is defined %}\n    ask_labels_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_labels_on_launch\n                             | default(template_overrides_global.job_template.ask_labels_on_launch)\n                             | default(current_job_templates_asset_value.ask_labels_on_launch | bool | lower) }}\n{% endif %}\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_forks_on_launch is defined\n      or template_overrides_global.job_template.ask_forks_on_launch is defined\n      or current_job_templates_asset_value.ask_forks_on_launch is defined %}\n    ask_forks_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_forks_on_launch\n                            | default(template_overrides_global.job_template.ask_forks_on_launch)\n                            | default(current_job_templates_asset_value.ask_forks_on_launch | bool | lower) }}\n{% endif %}\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_job_slice_count_on_launch is defined\n      or template_overrides_global.job_template.ask_job_slice_count_on_launch is defined\n      or current_job_templates_asset_value.ask_job_slice_count_on_launch is defined %}\n    ask_job_slice_count_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_job_slice_count_on_launch\n                                      | default(template_overrides_global.job_template.ask_job_slice_count_on_launch)\n                                      | default(current_job_templates_asset_value.ask_job_slice_count_on_launch | bool | lower) }}\n{% endif %}\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_timeout_on_launch is defined\n      or template_overrides_global.job_template.ask_timeout_on_launch is defined\n      or current_job_templates_asset_value.ask_timeout_on_launch is defined %}\n    ask_timeout_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_timeout_on_launch\n                              | default(template_overrides_global.job_template.ask_timeout_on_launch)\n                              | default(current_job_templates_asset_value.ask_timeout_on_launch | bool | lower) }}\n{% endif %}\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_instance_groups_on_launch is defined\n      or template_overrides_global.job_template.ask_instance_groups_on_launch is defined\n      or current_job_templates_asset_value.ask_instance_groups_on_launch is defined %}\n    ask_instance_groups_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_instance_groups_on_launch\n                                      | default(template_overrides_global.job_template.ask_instance_groups_on_launch)\n                                      | default(current_job_templates_asset_value.ask_instance_groups_on_launch | bool | lower) }}\n{% endif %}\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].extra_vars is defined\n      or template_overrides_global.job_template.extra_vars is defined\n      or current_job_templates_asset_value.extra_vars and current_job_templates_asset_value.extra_vars | length > 3 %}\n    extra_vars:\n      {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].extra_vars\n         | default(template_overrides_global.job_template.extra_vars)\n         | default(current_job_templates_asset_value.extra_vars)\n         | from_yaml | to_nice_yaml(indent=2, sort_keys=False)\n         | indent(width=6, first=False)\n         | regex_replace('(^[^:]*): (.*){([{%])', '\\\\g<1>: !unsafe \\\\g<2>{\\\\g<3>', multiline=True)\n      }}\n{%- endif %}\n    job_tags: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].job_tags\n                  | default(template_overrides_global.job_template.job_tags)\n                  | default(current_job_templates_asset_value.job_tags) }}\"\n    force_handlers: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].force_handlers\n                       | default(template_overrides_global.job_template.force_handlers)\n                       | default(current_job_templates_asset_value.force_handlers | bool | lower) }}\n    skip_tags: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].skip_tags\n                   | default(template_overrides_global.job_template.skip_tags)\n                   | default(current_job_templates_asset_value.skip_tags) }}\"\n    start_at_task: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].start_at_task\n                       | default(template_overrides_global.job_template.start_at_task)\n                       | default(current_job_templates_asset_value.start_at_task) }}\"\n    timeout: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].timeout\n                | default(template_overrides_global.job_template.timeout)\n                | default(current_job_templates_asset_value.timeout | int) }}\n{% if is_aap and (template_overrides_resources.job_template[current_job_templates_asset_value.name].execution_environment is defined\n                  or template_overrides_global.job_template.execution_environment is defined\n                  or current_job_templates_asset_value.summary_fields.execution_environment is defined) %}\n    execution_environment: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].execution_environment\n                               | default(template_overrides_global.job_template.execution_environment)\n                               | default(current_job_templates_asset_value.summary_fields.execution_environment.name) }}\"\n{% endif %}\n{% if not is_aap %}\n    custom_virtualenv: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].custom_virtualenv\n                           | default(template_overrides_global.job_template.custom_virtualenv)\n                           | default(current_job_templates_asset_value.custom_virtualenv | default(omit)) }}\"\n{% endif %}\n    host_config_key: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].host_config_key\n                         | default(template_overrides_global.job_template.host_config_key)\n                         | default(current_job_templates_asset_value.host_config_key) }}\"\n{% if query_labels | length > 0 %}\n    labels:\n{% for label in query_labels %}\n      - \"{{ label.name }}\"\n{% endfor %}\n{% endif %}\n{% if query_notification_error | length > 0 %}\n    notification_templates_error:\n{% for notification_error  in query_notification_error %}\n      - \"{{ notification_error.name }}\"\n{% endfor %}\n{% endif %}\n{% if query_notification_started | length > 0 %}\n    notification_templates_started:\n{% for notification_started  in query_notification_started %}\n      - \"{{ notification_started.name }}\"\n{% endfor %}\n{% endif %}\n{% if query_notification_success | length > 0 %}\n    notification_templates_success:\n{% for notification_success  in query_notification_success %}\n      - \"{{ notification_success.name }}\"\n{% endfor %}\n{% endif %}\n    survey_enabled: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].survey_enabled\n                       | default(template_overrides_global.job_template.survey_enabled)\n                       | default(current_job_templates_asset_value.survey_enabled | bool | lower) }}\n{% set survey_spec_contents = template_overrides_resources.job_template[current_job_templates_asset_value.name].survey_spec\n                              | default(template_overrides_global.job_template.survey_spec)\n                              | default(query(controller_api_plugin, current_job_templates_asset_value.related.survey_spec,\n                                              host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs)[0])\n                              | from_yaml | to_nice_yaml(indent=2,width=500,sort_keys=False) | regex_replace(\"\\n\\n[ ]*\", \"\\\\\\\\n\")\n                              | indent(width=6, first=False) | regex_replace('(^[^:]*): (.*){([{%])', '\\\\g<1>: !unsafe \\\\g<2>{\\\\g<3>', multiline=True)\n                              | replace(\"^$\", \"\") | replace(\"$encrypted$\", \"\\'\\'\"))\n-%}\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].survey_spec is defined\n      or template_overrides_global.job_template.survey_spec is defined\n      or (current_job_templates_asset_value.related.survey_spec is defined and survey_spec_contents | length > 3) %}\n    survey_spec:\n      {{ survey_spec_contents }}\n{% endif %}\n    become_enabled: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].become_enabled\n                       | default(template_overrides_global.job_template.become_enabled)\n                       | default(current_job_templates_asset_value.become_enabled | bool | lower) }}\n    diff_mode: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].diff_mode\n                       | default(template_overrides_global.job_template.diff_mode)\n                       | default(current_job_templates_asset_value.diff_mode | bool | lower) }}\n    webhook_service: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].webhook_service\n                       | default(template_overrides_global.job_template.webhook_service)\n                       | default(current_job_templates_asset_value.webhook_service) }}\"\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].webhook_credential is defined\n      or template_overrides_global.job_template.webhook_credential is defined\n      or current_job_templates_asset_value.webhook_credential %}\n    webhook_credential: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].webhook_credential\n                            | default(template_overrides_global.job_template.webhook_credential)\n                            | default(current_job_templates_asset_value.webhook_credential) }}\"\n{% endif %}\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].prevent_instance_group_fallback is defined\n      or template_overrides_global.job_template.prevent_instance_group_fallback is defined\n      or current_job_templates_asset_value.prevent_instance_group_fallback is defined %}\n    prevent_instance_group_fallback: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].prevent_instance_group_fallback\n                                        | default(template_overrides_global.job_template.prevent_instance_group_fallback)\n                                        | default(current_job_templates_asset_value.prevent_instance_group_fallback | bool | lower) }}\n{% endif %}\n{% if last_job_template | default(true) | bool | lower %}\n...\n{% endif %}\n. unexpected ')'. template error while templating string: unexpected ')'. String: {% if (current_job_template_index | default(0)) == 0 %}\n---\ncontroller_templates:\n{% endif %}\n  - name: \"{{ current_job_templates_asset_value.name }}\"\n    description: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].description\n                     | default(template_overrides_global.job_template.description)\n                     | default(current_job_templates_asset_value.description)\n    }}\"\n    organization: \"{{ current_job_templates_asset_value.summary_fields.organization.name | default(organization if organization != 'ORGANIZATIONLESS' else 'ToDo: The job template \\'' + current_job_templates_asset_value.name + '\\' must belong to an organization') }}\"\n    project: \"{{ current_job_templates_asset_value.summary_fields.project.name | default('ToDo: The job template \\'' + current_job_templates_asset_value.name + '\\' must have a project assigned') }}\"\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].inventory is defined\n      or template_overrides_global.job_template.inventory is defined\n      or current_job_templates_asset_value.inventory %}\n    inventory: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].inventory\n                   | default(template_overrides_global.job_template.inventory)\n                   | default(current_job_templates_asset_value.summary_fields.inventory.name) }}\"\n{% endif %}\n    playbook: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].playbook\n                  | default(template_overrides_global.job_template.playbook)\n                  | default(current_job_templates_asset_value.playbook) }}\"\n    scm_branch: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].scm_branch\n                  | default(template_overrides_global.job_template.scm_branch)\n                  | default(current_job_templates_asset_value.scm_branch) }}\"\n    forks: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].forks\n                  | default(template_overrides_global.job_template.forks)\n                  | default(current_job_templates_asset_value.forks) }}\n    limit: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].limit\n                  | default(template_overrides_global.job_template.limit)\n                  | default(current_job_templates_asset_value.limit) }}\"\n    verbosity: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].verbosity\n                  | default(template_overrides_global.job_template.verbosity)\n                  | default(current_job_templates_asset_value.verbosity) }}\n    job_type: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].job_type\n                  | default(template_overrides_global.job_template.job_type)\n                  | default(current_job_templates_asset_value.job_type) }}\"\n    job_slice_count: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].job_slice_count\n                  | default(template_overrides_global.job_template.job_slice_count)\n                  | default(current_job_templates_asset_value.job_slice_count) }}\n    use_fact_cache: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].use_fact_cache\n                  | default(template_overrides_global.job_template.use_fact_cache)\n                  | default(current_job_templates_asset_value.use_fact_cache | bool | lower) }}\n{% if current_job_templates_asset_value.summary_fields.credentials %}\n    credentials:\n{% for credential in current_job_templates_asset_value.summary_fields.credentials %}\n      - \"{{ credential.name }}\"\n{% endfor %}\n{% endif %}\n    allow_simultaneous: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].allow_simultaneous\n                           | default(template_overrides_global.job_template.allow_simultaneous)\n                           | default(current_job_templates_asset_value.allow_simultaneous | bool | lower) }}\n    ask_scm_branch_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_scm_branch_on_launch\n                                 | default(template_overrides_global.job_template.ask_scm_branch_on_launch)\n                                 | default(current_job_templates_asset_value.ask_scm_branch_on_launch | bool | lower) }}\n    ask_diff_mode_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_diff_mode_on_launch\n                                | default(template_overrides_global.job_template.ask_diff_mode_on_launch)\n                                | default(current_job_templates_asset_value.ask_diff_mode_on_launch | bool | lower) }}\n    ask_tags_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_tags_on_launch\n                           | default(template_overrides_global.job_template.ask_tags_on_launch)\n                           | default(current_job_templates_asset_value.ask_tags_on_launch | bool | lower) }}\n    ask_skip_tags_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_skip_tags_on_launch\n                                | default(template_overrides_global.job_template.ask_skip_tags_on_launch)\n                                | default(current_job_templates_asset_value.ask_skip_tags_on_launch | bool | lower) }}\n    ask_job_type_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_job_type_on_launch\n                               | default(template_overrides_global.job_template.ask_job_type_on_launch)\n                               | default(current_job_templates_asset_value.ask_job_type_on_launch | bool | lower) }}\n    ask_verbosity_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_verbosity_on_launch\n                                | default(template_overrides_global.job_template.ask_verbosity_on_launch)\n                                | default(current_job_templates_asset_value.ask_verbosity_on_launch | bool | lower) }}\n    ask_variables_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_variables_on_launch\n                                | default(template_overrides_global.job_template.ask_variables_on_launch)\n                                | default(current_job_templates_asset_value.ask_variables_on_launch | bool | lower) }}\n    ask_inventory_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_inventory_on_launch\n                                | default(template_overrides_global.job_template.ask_inventory_on_launch)\n                                | default(current_job_templates_asset_value.ask_inventory_on_launch | bool | lower) }}\n    ask_limit_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_limit_on_launch\n                            | default(template_overrides_global.job_template.ask_limit_on_launch)\n                            | default(current_job_templates_asset_value.ask_limit_on_launch | bool | lower) }}\n    ask_credential_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_credential_on_launch\n                                 | default(template_overrides_global.job_template.ask_credential_on_launch)\n                                 | default(current_job_templates_asset_value.ask_credential_on_launch | bool | lower) }}\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_execution_environment_on_launch is defined\n      or template_overrides_global.job_template.ask_execution_environment_on_launch is defined\n      or current_job_templates_asset_value.ask_execution_environment_on_launch is defined %}\n    ask_execution_environment_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_execution_environment_on_launch\n                                            | default(template_overrides_global.job_template.ask_execution_environment_on_launch)\n                                            | default(current_job_templates_asset_value.ask_execution_environment_on_launch | bool | lower) }}\n{% endif %}\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_labels_on_launch is defined\n      or template_overrides_global.job_template.ask_labels_on_launch is defined\n      or current_job_templates_asset_value.ask_labels_on_launch is defined %}\n    ask_labels_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_labels_on_launch\n                             | default(template_overrides_global.job_template.ask_labels_on_launch)\n                             | default(current_job_templates_asset_value.ask_labels_on_launch | bool | lower) }}\n{% endif %}\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_forks_on_launch is defined\n      or template_overrides_global.job_template.ask_forks_on_launch is defined\n      or current_job_templates_asset_value.ask_forks_on_launch is defined %}\n    ask_forks_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_forks_on_launch\n                            | default(template_overrides_global.job_template.ask_forks_on_launch)\n                            | default(current_job_templates_asset_value.ask_forks_on_launch | bool | lower) }}\n{% endif %}\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_job_slice_count_on_launch is defined\n      or template_overrides_global.job_template.ask_job_slice_count_on_launch is defined\n      or current_job_templates_asset_value.ask_job_slice_count_on_launch is defined %}\n    ask_job_slice_count_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_job_slice_count_on_launch\n                                      | default(template_overrides_global.job_template.ask_job_slice_count_on_launch)\n                                      | default(current_job_templates_asset_value.ask_job_slice_count_on_launch | bool | lower) }}\n{% endif %}\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_timeout_on_launch is defined\n      or template_overrides_global.job_template.ask_timeout_on_launch is defined\n      or current_job_templates_asset_value.ask_timeout_on_launch is defined %}\n    ask_timeout_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_timeout_on_launch\n                              | default(template_overrides_global.job_template.ask_timeout_on_launch)\n                              | default(current_job_templates_asset_value.ask_timeout_on_launch | bool | lower) }}\n{% endif %}\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_instance_groups_on_launch is defined\n      or template_overrides_global.job_template.ask_instance_groups_on_launch is defined\n      or current_job_templates_asset_value.ask_instance_groups_on_launch is defined %}\n    ask_instance_groups_on_launch: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].ask_instance_groups_on_launch\n                                      | default(template_overrides_global.job_template.ask_instance_groups_on_launch)\n                                      | default(current_job_templates_asset_value.ask_instance_groups_on_launch | bool | lower) }}\n{% endif %}\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].extra_vars is defined\n      or template_overrides_global.job_template.extra_vars is defined\n      or current_job_templates_asset_value.extra_vars and current_job_templates_asset_value.extra_vars | length > 3 %}\n    extra_vars:\n      {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].extra_vars\n         | default(template_overrides_global.job_template.extra_vars)\n         | default(current_job_templates_asset_value.extra_vars)\n         | from_yaml | to_nice_yaml(indent=2, sort_keys=False)\n         | indent(width=6, first=False)\n         | regex_replace('(^[^:]*): (.*){([{%])', '\\\\g<1>: !unsafe \\\\g<2>{\\\\g<3>', multiline=True)\n      }}\n{%- endif %}\n    job_tags: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].job_tags\n                  | default(template_overrides_global.job_template.job_tags)\n                  | default(current_job_templates_asset_value.job_tags) }}\"\n    force_handlers: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].force_handlers\n                       | default(template_overrides_global.job_template.force_handlers)\n                       | default(current_job_templates_asset_value.force_handlers | bool | lower) }}\n    skip_tags: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].skip_tags\n                   | default(template_overrides_global.job_template.skip_tags)\n                   | default(current_job_templates_asset_value.skip_tags) }}\"\n    start_at_task: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].start_at_task\n                       | default(template_overrides_global.job_template.start_at_task)\n                       | default(current_job_templates_asset_value.start_at_task) }}\"\n    timeout: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].timeout\n                | default(template_overrides_global.job_template.timeout)\n                | default(current_job_templates_asset_value.timeout | int) }}\n{% if is_aap and (template_overrides_resources.job_template[current_job_templates_asset_value.name].execution_environment is defined\n                  or template_overrides_global.job_template.execution_environment is defined\n                  or current_job_templates_asset_value.summary_fields.execution_environment is defined) %}\n    execution_environment: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].execution_environment\n                               | default(template_overrides_global.job_template.execution_environment)\n                               | default(current_job_templates_asset_value.summary_fields.execution_environment.name) }}\"\n{% endif %}\n{% if not is_aap %}\n    custom_virtualenv: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].custom_virtualenv\n                           | default(template_overrides_global.job_template.custom_virtualenv)\n                           | default(current_job_templates_asset_value.custom_virtualenv | default(omit)) }}\"\n{% endif %}\n    host_config_key: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].host_config_key\n                         | default(template_overrides_global.job_template.host_config_key)\n                         | default(current_job_templates_asset_value.host_config_key) }}\"\n{% if query_labels | length > 0 %}\n    labels:\n{% for label in query_labels %}\n      - \"{{ label.name }}\"\n{% endfor %}\n{% endif %}\n{% if query_notification_error | length > 0 %}\n    notification_templates_error:\n{% for notification_error  in query_notification_error %}\n      - \"{{ notification_error.name }}\"\n{% endfor %}\n{% endif %}\n{% if query_notification_started | length > 0 %}\n    notification_templates_started:\n{% for notification_started  in query_notification_started %}\n      - \"{{ notification_started.name }}\"\n{% endfor %}\n{% endif %}\n{% if query_notification_success | length > 0 %}\n    notification_templates_success:\n{% for notification_success  in query_notification_success %}\n      - \"{{ notification_success.name }}\"\n{% endfor %}\n{% endif %}\n    survey_enabled: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].survey_enabled\n                       | default(template_overrides_global.job_template.survey_enabled)\n                       | default(current_job_templates_asset_value.survey_enabled | bool | lower) }}\n{% set survey_spec_contents = template_overrides_resources.job_template[current_job_templates_asset_value.name].survey_spec\n                              | default(template_overrides_global.job_template.survey_spec)\n                              | default(query(controller_api_plugin, current_job_templates_asset_value.related.survey_spec,\n                                              host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs)[0])\n                              | from_yaml | to_nice_yaml(indent=2,width=500,sort_keys=False) | regex_replace(\"\\n\\n[ ]*\", \"\\\\\\\\n\")\n                              | indent(width=6, first=False) | regex_replace('(^[^:]*): (.*){([{%])', '\\\\g<1>: !unsafe \\\\g<2>{\\\\g<3>', multiline=True)\n                              | replace(\"^$\", \"\") | replace(\"$encrypted$\", \"\\'\\'\"))\n-%}\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].survey_spec is defined\n      or template_overrides_global.job_template.survey_spec is defined\n      or (current_job_templates_asset_value.related.survey_spec is defined and survey_spec_contents | length > 3) %}\n    survey_spec:\n      {{ survey_spec_contents }}\n{% endif %}\n    become_enabled: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].become_enabled\n                       | default(template_overrides_global.job_template.become_enabled)\n                       | default(current_job_templates_asset_value.become_enabled | bool | lower) }}\n    diff_mode: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].diff_mode\n                       | default(template_overrides_global.job_template.diff_mode)\n                       | default(current_job_templates_asset_value.diff_mode | bool | lower) }}\n    webhook_service: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].webhook_service\n                       | default(template_overrides_global.job_template.webhook_service)\n                       | default(current_job_templates_asset_value.webhook_service) }}\"\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].webhook_credential is defined\n      or template_overrides_global.job_template.webhook_credential is defined\n      or current_job_templates_asset_value.webhook_credential %}\n    webhook_credential: \"{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].webhook_credential\n                            | default(template_overrides_global.job_template.webhook_credential)\n                            | default(current_job_templates_asset_value.webhook_credential) }}\"\n{% endif %}\n{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].prevent_instance_group_fallback is defined\n      or template_overrides_global.job_template.prevent_instance_group_fallback is defined\n      or current_job_templates_asset_value.prevent_instance_group_fallback is defined %}\n    prevent_instance_group_fallback: {{ template_overrides_resources.job_template[current_job_templates_asset_value.name].prevent_instance_group_fallback\n                                        | default(template_overrides_global.job_template.prevent_instance_group_fallback)\n                                        | default(current_job_templates_asset_value.prevent_instance_group_fallback | bool | lower) }}\n{% endif %}\n{% if last_job_template | default(true) | bool | lower %}\n...\n{% endif %}\n. unexpected ')'"
}
```
