### PR TITLE
Issue with null in extra_data of schedules

### DIFF
--- a/changelogs/fragments/filetree_create_schedule_extra_data_issue.yml
+++ b/changelogs/fragments/filetree_create_schedule_extra_data_issue.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - filetree_create no longer export schedules extra data when extra_vars of job template is empty (null issue)
+...

--- a/roles/filetree_create/templates/controller_schedules.j2
+++ b/roles/filetree_create/templates/controller_schedules.j2
@@ -66,7 +66,7 @@ controller_schedules:
 {% endif %}
 {% if template_overrides_resources.schedule[current_schedules_asset_value.name].extra_data is defined
       or template_overrides_global.schedule.extra_data is defined
-      or current_schedules_asset_value.extra_data is defined %}
+      or current_schedules_asset_value.extra_data is defined and current_schedules_asset_value.extra_data | length > 0 %}
     extra_data:
       {{ template_overrides_resources.schedule[current_schedules_asset_value.name].extra_data
          | default(template_overrides_global.schedule.extra_data)


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Hi, this PR fixes an issue where, if the JT does not have extra_vars defined, the schedule is exported with null inside the extra_data

```yaml
    extra_data:
      null
      ...
```
# How should this be tested?
Manually.

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

# Other Relevant info, PRs, etc
N/A