### PR TITLE
fix missing verbosity for WF node

### DIFF
--- a/changelogs/fragments/filetree_create_node_verbosity_issue.yml
+++ b/changelogs/fragments/filetree_create_node_verbosity_issue.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - filetree_create export missing verbosity for node
+...

--- a/roles/filetree_create/templates/controller_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/controller_workflow_job_templates.j2
@@ -22,6 +22,7 @@ controller_workflows:
         workflow_job_template: "{{ node.summary_fields.workflow_job_template.name }}"
 {% if node.summary_fields.unified_job_template.unified_job_type is not match('approval') %}
         unified_job_template: "{{ node.summary_fields.unified_job_template.name | default('ToDo: The node is pointing to a deleted Job Template') }}"
+        verbosity: "{{ node.verbosity if node.verbosity != None else '0' }}"
 {% endif %}
 {% if node.limit is defined %}
         limit: "{{ node.limit }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
This PR addresses an issue occurring when a Workflow (WF) node has a `null` value in the verbosity setting in the API response.

When the import process does not receive a verbosity level, it defaults to null.

Steps to Reproduce (AAP 2.4, I don't know if it occurs on 2.5):

1) Add a job template to a workflow.
2) Modify the job template by enabling to modify the verbosity upon launch option.
3) Open the Workflow Visualizer and attempt to view node details using the `View node details` option.
4) The issue occurs, as shown below:

![image](https://github.com/user-attachments/assets/7c777f9d-ecb2-4fa9-b5d6-1e8bbc5c36b7)


# How should this be tested?
Manually.

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

# Other Relevant info, PRs, etc
N/A