### PR TITLE
Fix extra vars issue

### DIFF
--- a/changelogs/fragments/filetree_create_missing_extra_vars.yml
+++ b/changelogs/fragments/filetree_create_missing_extra_vars.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - filetree_create is able to export empty extra vars of JT and WF
+...

--- a/roles/filetree_create/templates/controller_job_templates.j2
+++ b/roles/filetree_create/templates/controller_job_templates.j2
@@ -140,7 +140,9 @@ controller_templates:
       {{ extra_vars_item.key }}: {{ (extra_vars_item.value | regex_replace("\n", "\\\\n") | regex_replace('"', '\\"')) | regex_replace('(^[^{]*){([{%])(.*)', '!unsafe "\\g<1>{\\g<2>\\g<3>"', multiline=True) }}
 {%     endif %}
 {%   endfor %}
-{%- endif %}
+{% else %}
+    extra_vars: ""
+{% endif %}
     job_tags: "{{ template_overrides_resources.job_template[current_job_templates_asset_value.name].job_tags
                   | default(template_overrides_global.job_template.job_tags)
                   | default(current_job_templates_asset_value.job_tags) }}"

--- a/roles/filetree_create/templates/controller_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/controller_workflow_job_templates.j2
@@ -112,6 +112,8 @@ controller_workflows:
       {{ extra_vars_item.key }}: {{ (extra_vars_item.value | regex_replace("\n", "\\\\n") | regex_replace('"', '\\"')) | regex_replace('(^[^{]*){([{%])(.*)', '!unsafe "\\g<1>{\\g<2>\\g<3>"', multiline=True) }}
 {%     endif %}
 {%   endfor %}
+{% else %}
+    extra_vars: ""
 {%- endif %}
 {% if query_labels | length > 0 %}
     labels:

--- a/roles/filetree_create/templates/controller_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/controller_workflow_job_templates.j2
@@ -114,7 +114,7 @@ controller_workflows:
 {%   endfor %}
 {% else %}
     extra_vars: ""
-{%- endif %}
+{% endif %}
 {% if query_labels | length > 0 %}
     labels:
 {% for label in query_labels %}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
This PR fixes an issue where the extra_vars field of a Job Template or Workflow is empty and is not included in the YAML file. As a result, when the import is performed, the extra_vars on the target AAP are not cleared

# How should this be tested?
Manually.

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

# Other Relevant info, PRs, etc
N/A