### PR TITLE
fixed job template issue with empty survey spec

### DIFF
--- a/roles/filetree_create/templates/controller_job_templates.j2
+++ b/roles/filetree_create/templates/controller_job_templates.j2
@@ -201,7 +201,7 @@ controller_templates:
 {% set survey_spec_contents = template_overrides_resources.job_template[current_job_templates_asset_value.name].survey_spec
                               | default(template_overrides_global.job_template.survey_spec)
                               | default(query(controller_api_plugin, current_job_templates_asset_value.related.survey_spec,
-                                              host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs))
+                                    host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs) | difference([{}]) )
 -%}
 {% if template_overrides_resources.job_template[current_job_templates_asset_value.name].survey_spec is defined
       or template_overrides_global.job_template.survey_spec is defined


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
filetree_create failed when job template has no survey spec

It seems the query for related survey_spec returns a list with a single empty dictionary, i.e. `[{}]`, which causes the following condition check of `survey_spec_contents | length > 0` to pass even there is no survey spec.

This PR added a filter `difference([{}])` to remove the empty dictionary from the returned list.

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
Run filetree_create role against job template with no survey spec defined

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
None

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
