### PR TITLE
fix wrong fact used

### DIFF
--- a/roles/filetree_read/tasks/teams.yml
+++ b/roles/filetree_read/tasks/teams.yml
@@ -20,7 +20,7 @@
 
 - name: "Set Roles Data Structure"
   ansible.builtin.set_fact:
-    controller_roles: >-
+    aap_teams: >-
       {{
         __contents_filetree_aap_teams.results |
         rejectattr('ansible_facts.aap_teams', 'undefined') |

--- a/roles/filetree_read/tasks/teams.yml
+++ b/roles/filetree_read/tasks/teams.yml
@@ -18,7 +18,7 @@
   register: __contents_filetree_aap_teams
   failed_when: "'VARIABLE IS NOT DEFINED' in __contents_filetree_aap_teams"
 
-- name: "Set Roles Data Structure"
+- name: "Set Teams Data Structure"
   ansible.builtin.set_fact:
     aap_teams: >-
       {{


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Fixes the wrong fact used for consolidating the `aap_teams` vars

# How should this be tested?
Execute using the `teams` tag

# Is there a relevant Issue open for this?
possibly resolves #44

# Other Relevant info, PRs, etc
N/A
