### PR TITLE
fix for when source project is null

### DIFF
--- a/roles/filetree_create/templates/controller_inventory_sources.j2
+++ b/roles/filetree_create/templates/controller_inventory_sources.j2
@@ -16,7 +16,7 @@ controller_inventory_sources:
                 | default('ToDo: The source of the inventory_source was originally missing and must be specified', true) }}"
 {% if template_overrides_resources.inventory_source[inventory_source.name].source_project is defined
       or template_overrides_global.inventory_source.source_project is defined
-      or inventory_source.source_project is defined %}
+      or (inventory_source.source_project is defined and inventory_source.source_project != None) %}
     source_project: "{{ template_overrides_resources.inventory_source[inventory_source.name].source_project
                         | default(template_overrides_global.inventory_source.source_project)
                         | default(inventory_source.summary_fields.source_project.name) }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Fixes an issue where `source_project` is `null` in the Controller API, and the Inventory Source template fails

# How should this be tested?
Run `filetree_create` role when you have an Inventory Source that doesn't have a source project. `vmware`, `ec2` (AWS), or `azure_rm` for myself:
![image](https://github.com/user-attachments/assets/fc486ed6-c51d-4743-904a-d42a2bb9b9a6)


# Is there a relevant Issue open for this?
N/A

# Other Relevant info, PRs, etc
N/A
