### PR TITLE
possible fix for when survey_spec_contents.name is not defined

### DIFF
--- a/roles/filetree_create/templates/controller_job_templates.j2
+++ b/roles/filetree_create/templates/controller_job_templates.j2
@@ -207,7 +207,7 @@ controller_templates:
 -%}
 {% if template_overrides_resources.job_template[current_job_templates_asset_value.name].survey_spec is defined
       or template_overrides_global.job_template.survey_spec is defined
-      or (current_job_templates_asset_value.related.survey_spec is defined and survey_spec_contents | length > 0) %}
+      or (current_job_templates_asset_value.related.survey_spec is defined and survey_spec_contents | length > 0 and survey_spec_contents[0].name is defined) %}
     survey_spec:
 {% for spec_item in survey_spec_contents %}
       name: "{{ spec_item.name }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
So, there may be a better way to fix it, but this fixed it for me.  All of my templates that didn't have any survey questions were failing because the dict item `spec_item` didn't have `name` (line 213).  I didn't have an issue in 2.4, but did as soon as I used this new role in 2.5. I don't know why the exiting `| length > 0` wasn't enough.

# How should this be tested?
For me, it just took me using it against job_templates that did NOT have ANY survey questions:

![image](https://github.com/user-attachments/assets/927b3aac-7e1b-477f-9968-b9db2bf7de05)

# Is there a relevant Issue open for this?
N/A

# Other Relevant info, PRs, etc
N/A
