### PR TITLE
fix: issue when verbosity for node was exported while it was not needed

### DIFF
--- a/changelogs/fragments/filetree_create_node_verbosity_added_when_not_needed.yaml
+++ b/changelogs/fragments/filetree_create_node_verbosity_added_when_not_needed.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - filetree_create export verbosity for node when ask_verbosity_on_launch is defined
+...

--- a/roles/filetree_create/templates/controller_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/controller_workflow_job_templates.j2
@@ -22,7 +22,17 @@ controller_workflows:
         workflow_job_template: "{{ node.summary_fields.workflow_job_template.name }}"
 {% if node.summary_fields.unified_job_template.unified_job_type is not match('approval') %}
         unified_job_template: "{{ node.summary_fields.unified_job_template.name | default('ToDo: The node is pointing to a deleted Job Template') }}"
-        verbosity: "{{ node.verbosity if node.verbosity != None else '0' }}"
+{%   if node.verbosity != None %}
+        verbosity: "{{ node.verbosity }}"
+{%   else %}
+{%     set jt_var = query(controller_api_plugin, 'api/controller/v2/job_templates',
+                          query_params={'name': node.summary_fields.unified_job_template.name},
+                          host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs,
+                          return_all=true, max_objects=query_controller_api_max_objects)[0] %}
+{%     if jt_var.ask_verbosity_on_launch %}
+        verbosity = "0"
+{%     endif %}
+{%   endif %}
 {% endif %}
 {% if node.limit is defined %}
         limit: "{{ node.limit }}"

--- a/roles/filetree_create/templates/controller_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/controller_workflow_job_templates.j2
@@ -30,7 +30,7 @@ controller_workflows:
                           host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs,
                           return_all=true, max_objects=query_controller_api_max_objects)[0] %}
 {%     if jt_var.ask_verbosity_on_launch %}
-        verbosity = "0"
+        verbosity = "{{ jt_var.verbosity }}"
 {%     endif %}
 {%   endif %}
 {% endif %}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Hey, PR fix issue when `ask_verbosity_on_launch` is not set in the JT of WF and verbosity should not be exported.
# How should this be tested?
Manually.

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A
# Other Relevant info, PRs, etc
#53 