### PR TITLE
fix export issue with empty surveys

### DIFF
--- a/changelogs/fragments/filetree_create_survey_issue.yaml
+++ b/changelogs/fragments/filetree_create_survey_issue.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - filetree_create job_template and workflow_job_template survey was failing when it was empty
+...

--- a/roles/filetree_create/templates/controller_job_templates.j2
+++ b/roles/filetree_create/templates/controller_job_templates.j2
@@ -207,7 +207,7 @@ controller_templates:
 -%}
 {% if template_overrides_resources.job_template[current_job_templates_asset_value.name].survey_spec is defined
       or template_overrides_global.job_template.survey_spec is defined
-      or (current_job_templates_asset_value.related.survey_spec is defined and survey_spec_contents | length > 0) %}
+      or (current_job_templates_asset_value.related.survey_spec is defined and survey_spec_contents | length > 0 and survey_spec_contents | first | length > 0) %}
     survey_spec:
 {% for spec_item in survey_spec_contents %}
       name: "{{ spec_item.name }}"

--- a/roles/filetree_create/templates/controller_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/controller_workflow_job_templates.j2
@@ -156,7 +156,7 @@ controller_workflows:
 -%}
 {% if template_overrides_resources.workflow_job_template[current_workflow_job_templates_asset_value.name].survey_spec is defined
       or template_overrides_global.workflow_job_template.survey_spec is defined
-      or (current_workflow_job_templates_asset_value.related.survey_spec is defined and survey_spec_contents | length > 0) %}
+      or (current_workflow_job_templates_asset_value.related.survey_spec is defined and survey_spec_contents | length > 0 and survey_spec_contents | first | length > 0) %}
     survey_spec:
 {% for spec_item in survey_spec_contents %}
       name: "{{ spec_item.name }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
When a (Workflow) Job Template had the survey disabled and empty, the exportation process was failing:

```
TASK [infra.aap_configuration_extended.filetree_create : Add current job_templates to the <ORGANIZATION_NAME>/controller_job_templates output file in /tmp/filetree_output_default] *********************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'dict object' has no attribute 'name'. 'dict object' has no attribute 'name'
failed: [localhost] (item=/tmp/filetree_output_default/Default/controller_job_templates/7_Demo Job Template.yaml) => {"ansible_loop_var": "current_job_templates_asset_value", "changed": false, "current_job_templates_asset_value": {"allow_simultaneous": false, "ask_credential_on_launch": false, "ask_diff_mode_on_launch": false, "ask_execution_environment_on_launch": false, "ask_forks_on_launch": false, "ask_instance_groups_on_launch": false, "ask_inventory_on_launch": false, "ask_job_slice_count_on_launch": false, "ask_job_type_on_launch": false, "ask_labels_on_launch": false, "ask_limit_on_launch": false, "ask_scm_branch_on_launch": false, "ask_skip_tags_on_launch": false, "ask_tags_on_launch": false, "ask_timeout_on_launch": false, "ask_variables_on_launch": false, "ask_verbosity_on_launch": false, "become_enabled": false, "created": "2025-01-22T15:07:51.767199Z", "custom_virtualenv": null, "description": "", "diff_mode": false, "execution_environment": null, "extra_vars": "", "force_handlers": false, "forks": 0, "host_config_key": "", "id": 7, "inventory": 1, "job_slice_count": 1, "job_tags": "", "job_type": "run", "last_job_failed": false, "last_job_run": null, "limit": "", "modified": "2025-01-22T15:07:51.767206Z", "name": "Demo Job Template", "next_job_run": null, "organization": 1, "playbook": "hello_world.yml", "prevent_instance_group_fallback": false, "project": 6, "related": {"access_list": "/api/controller/v2/job_templates/7/access_list/", "activity_stream": "/api/controller/v2/job_templates/7/activity_stream/", "copy": "/api/controller/v2/job_templates/7/copy/", "created_by": "/api/controller/v2/users/1/", "credentials": "/api/controller/v2/job_templates/7/credentials/", "instance_groups": "/api/controller/v2/job_templates/7/instance_groups/", "inventory": "/api/controller/v2/inventories/1/", "jobs": "/api/controller/v2/job_templates/7/jobs/", "labels": "/api/controller/v2/job_templates/7/labels/", "launch": "/api/controller/v2/job_templates/7/launch/", "modified_by": "/api/controller/v2/users/1/", "notification_templates_error": "/api/controller/v2/job_templates/7/notification_templates_error/", "notification_templates_started": "/api/controller/v2/job_templates/7/notification_templates_started/", "notification_templates_success": "/api/controller/v2/job_templates/7/notification_templates_success/", "object_roles": "/api/controller/v2/job_templates/7/object_roles/", "organization": "/api/controller/v2/organizations/1/", "project": "/api/controller/v2/projects/6/", "schedules": "/api/controller/v2/job_templates/7/schedules/", "slice_workflow_jobs": "/api/controller/v2/job_templates/7/slice_workflow_jobs/", "survey_spec": "/api/controller/v2/job_templates/7/survey_spec/", "webhook_key": "/api/controller/v2/job_templates/7/webhook_key/", "webhook_receiver": ""}, "scm_branch": "", "skip_tags": "", "start_at_task": "", "status": "never updated", "summary_fields": {"created_by": {"first_name": "", "id": 1, "last_name": "", "username": "admin"}, "credentials": [{"cloud": false, "description": "", "id": 1, "kind": "ssh", "name": "Demo Credential"}], "inventory": {"description": "", "has_active_failures": false, "has_inventory_sources": false, "hosts_with_active_failures": 0, "id": 1, "inventory_sources_with_failures": 0, "kind": "", "name": "Demo Inventory", "organization_id": 1, "total_groups": 0, "total_hosts": 0, "total_inventory_sources": 0}, "labels": {"count": 0, "results": []}, "modified_by": {"first_name": "", "id": 1, "last_name": "", "username": "admin"}, "object_roles": {"admin_role": {"description": "Can manage all aspects of the job template", "id": 35, "name": "Admin"}, "execute_role": {"description": "May run the job template", "id": 36, "name": "Execute"}, "read_role": {"description": "May view settings for the job template", "id": 37, "name": "Read"}}, "organization": {"description": "The default organization for Ansible Automation Platform", "id": 1, "name": "Default"}, "project": {"allow_override": false, "description": "", "id": 6, "name": "Demo Project", "scm_type": "git", "status": "successful"}, "recent_jobs": [], "user_capabilities": {"copy": true, "delete": true, "edit": true, "schedule": true, "start": true}}, "survey_enabled": false, "timeout": 0, "type": "job_template", "url": "/api/controller/v2/job_templates/7/", "use_fact_cache": false, "verbosity": 0, "webhook_credential": null, "webhook_service": ""}, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'name'. 'dict object' has no attribute 'name'"}

```

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
Tested manually
# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
<!--- resolves #[number] -->

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
N/A