### PR TITLE
fix: issue when hostfilter is complicated and it requires to be quoted

### DIFF
--- a/changelogs/fragments/filetree_create_hostfilter_missing_quotes.yaml
+++ b/changelogs/fragments/filetree_create_hostfilter_missing_quotes.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - filetree_create missing single quotes for hostfilter in smart inventories
+...

--- a/roles/filetree_create/templates/controller_inventories.j2
+++ b/roles/filetree_create/templates/controller_inventories.j2
@@ -10,9 +10,9 @@ controller_inventories:
 {% if template_overrides_resources.inventory[current_inventories_asset_value.name].host_filter is defined
       or template_overrides_global_global.inventory.host_filter is defined
       or current_inventories_asset_value.host_filter is defined %}
-    host_filter: {{ template_overrides_resources.inventory[current_inventories_asset_value.name].host_filter
+    host_filter: '{{ template_overrides_resources.inventory[current_inventories_asset_value.name].host_filter
                      | default(template_overrides_global.inventory.host_filter)
-                     | default(current_inventories_asset_value.host_filter if (current_inventories_asset_value.host_filter|type_debug != 'NoneType') else '""') | replace("'",'"') }}
+                     | default(current_inventories_asset_value.host_filter if (current_inventories_asset_value.host_filter|type_debug != 'NoneType') else '""') | replace("'",'"') }}'
 {% endif %}
 {% if current_inventories_asset_value.kind %}
     kind: "{{ current_inventories_asset_value.kind }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
This PR add single quotes for hostfilter. This filter was breaking loading yaml file.

``` yaml
host_filter: (inventory__name=uuc_inventory_main) and ((variables__iregex="^(?!.*unmanagedServer).*$") and ((variables__iregex="^.*\042status\042: \042{0,1}Prod.*\042{0,1}\,.*$") or (variables__iregex="^.*\042status\042: \042{0,1}Prod.*\042{0,1}\s*\175$") or (variables__iregex="^status: Prod.*\n.*$") or (variables__iregex="^.*\nstatus: Prod.*\n.*$") or (variables__iregex="^.*\nstatus: Prod.*\s*$"))) and ((groups__name=redacted) or (groups__name=redacted) or (groups__name=redacted)) and ((name__startswith="redacted") or (name__startswith="redacted"))
```
Edit: I believe, it was somehow overlooked in previous PR.
# How should this be tested?
Manually.

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

# Other Relevant info, PRs, etc
#28