### PR TITLE
feat: disable hosts export for smart and constructed inventories

### DIFF
--- a/changelogs/fragments/filetree_create_smart_constructed_inventory_hosts_export.yml
+++ b/changelogs/fragments/filetree_create_smart_constructed_inventory_hosts_export.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - filetree_create should not export hosts of smart/constructed inventories as they are based on existing inventories
+...

--- a/roles/filetree_create/tasks/controller_inventory.yml
+++ b/roles/filetree_create/tasks/controller_inventory.yml
@@ -113,7 +113,7 @@
 
 - name: "Set the inventory's hosts"
   ansible.builtin.include_tasks: "controller_hosts.yml"
-  when: not skip_inventory_hosts and current_inventory_hosts.kind is not match('smart') and current_invenentory_hosts.kind is not match('constructed')
+  when: (not skip_inventory_hosts and current_inventory_hosts.kind is not match('smart') and current_invenentory_hosts.kind is not match('constructed')) or (not skip_inventory_hosts and inventory_id is defined)
   vars:
     inventory_organization: "{{ current_inventory_hosts.summary_fields.organization.name | default(organization) }}"
     inventory_name: "{{ current_inventory_hosts.name | regex_replace('/', '_') }}"

--- a/roles/filetree_create/tasks/controller_inventory.yml
+++ b/roles/filetree_create/tasks/controller_inventory.yml
@@ -113,7 +113,7 @@
 
 - name: "Set the inventory's hosts"
   ansible.builtin.include_tasks: "controller_hosts.yml"
-  when: not skip_inventory_hosts
+  when: not skip_inventory_hosts and current_inventory_hosts.kind is not match('smart') and current_invenentory_hosts.kind is not match('constructed')
   vars:
     inventory_organization: "{{ current_inventory_hosts.summary_fields.organization.name | default(organization) }}"
     inventory_name: "{{ current_inventory_hosts.name | regex_replace('/', '_') }}"

--- a/roles/filetree_create/tasks/controller_inventory.yml
+++ b/roles/filetree_create/tasks/controller_inventory.yml
@@ -113,7 +113,7 @@
 
 - name: "Set the inventory's hosts"
   ansible.builtin.include_tasks: "controller_hosts.yml"
-  when: (not skip_inventory_hosts and current_inventory_hosts.kind is not match('smart') and current_invenentory_hosts.kind is not match('constructed')) or (not skip_inventory_hosts and inventory_id is defined)
+  when: (not skip_inventory_hosts and current_inventory_hosts.kind is not search('smart|constructed')) or (not skip_inventory_hosts and inventory_id is defined)
   vars:
     inventory_organization: "{{ current_inventory_hosts.summary_fields.organization.name | default(organization) }}"
     inventory_name: "{{ current_inventory_hosts.name | regex_replace('/', '_') }}"

--- a/roles/filetree_create/tasks/controller_inventory.yml
+++ b/roles/filetree_create/tasks/controller_inventory.yml
@@ -117,7 +117,7 @@
   vars:
     inventory_organization: "{{ current_inventory_hosts.summary_fields.organization.name | default(organization) }}"
     inventory_name: "{{ current_inventory_hosts.name | regex_replace('/', '_') }}"
-    hosts_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/controller_inventories/' + inventory_name | regex_replace('/', '_'))
+    hosts_output_path: "{{ (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/controller_inventories/' + inventory_name | regex_replace('/', '_'))
                           if (flatten_output is not defined or (flatten_output | bool) == false)
                           else
                             output_path + '/controller_hosts.yaml' }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
This PR is disabling export of hosts for smart and constructed inventories. As they are based on existing inventories I think it is waste of time to export hosts but I added one condition to still allow to export hosts, if someone use inventory_id.

# How should this be tested?
Manually.

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A
# Other Relevant info, PRs, etc
N/A