### PR TITLE
Add credential_input_sources to filetree_create

### DIFF
--- a/changelogs/fragments/filetree_create_credential_input_sources.yml
+++ b/changelogs/fragments/filetree_create_credential_input_sources.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Add credential_input_sources to the filetree create
+...

--- a/roles/filetree_create/tasks/controller_credential_input_sources.yml
+++ b/roles/filetree_create/tasks/controller_credential_input_sources.yml
@@ -1,0 +1,60 @@
+---
+- name: "Get current input source from the API"
+  ansible.builtin.set_fact:
+    credential_input_sources_lookvar: "{{ query(controller_api_plugin, 'api/controller/v2/credentials/' + __credential_id + '/input_sources/',
+                                  host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs,
+                                  return_all=true, max_objects=query_controller_api_max_objects)
+                         }}"
+  vars:
+    __credential_id: "{{ current_credential['id'] }}"
+  no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
+
+- name: "Block for to generate flatten output"
+  when:
+    - flatten_output is defined
+    - flatten_output | bool
+    - credential_input_sources_lookvar | length > 0
+  vars:
+    __dest: "{{ output_path }}/controller_credential_input_sources.yaml"
+  block:
+    - name: "Stat if the output file exists"
+      ansible.builtin.stat:
+        path: "{{ __dest }}"
+      register: credential_input_source_file
+
+    - name: "Add current credential input source to the flat file"
+      ansible.builtin.blockinfile:
+        create: true
+        mode: "0644"
+        insertafter: EOF
+        path: "{{ __dest }}"
+        marker: ""
+        block: "{{ lookup('template', 'templates/controller_credential_input_sources.j2') }}"
+      vars:
+        first_credential_input_source: "{{ not credential_input_source_file.stat.exists }}"
+      when: credential_input_sources_lookvar | length > 0
+
+    - name: "Remove all the blank lines introduced by the last task"
+      ansible.builtin.lineinfile:
+        path: "{{ __dest }}"
+        line: ''
+        state: absent
+
+- name: "Block for to generate the filetree_create normal output"
+  when:
+    - flatten_output is not defined or not (flatten_output | bool)
+    - credential_input_sources_lookvar | length > 0
+  block:
+    - name: "Create the output directory for controller_credential_input_sources: {{ output_path }}"
+      ansible.builtin.file:
+        path: "{{ normal_path }}/controller_credential_input_sources"
+        state: directory
+        mode: '0755'
+
+    - name: "Add current credential input sources to the output yaml file"
+      ansible.builtin.template:
+        src: "templates/controller_credential_input_sources.j2"
+        dest: "{{ normal_path }}/controller_credential_input_sources/controller_credential_input_sources_{{ current_credential['name'] | regex_replace('/', '_') }}.yaml"
+        mode: '0644'
+      when: credential_input_sources_lookvar | length > 0
+...

--- a/roles/filetree_create/tasks/controller_credentials.yml
+++ b/roles/filetree_create/tasks/controller_credentials.yml
@@ -76,4 +76,16 @@
       loop_control:
         loop_var: current_credentials_asset_value
         label: "{{ __dest }}"
+
+- name: "Set the credential's input sources"
+  ansible.builtin.include_tasks: "controller_credential_input_sources.yml"
+  vars:
+    credential: "{{ current_credential.name }}"
+    credentials_organization: "{{ current_credential.summary_fields.organization.name | default(organization) }}"
+    last_credential: "{{ current_credential_index == ((credentials_lookvar | length) - 1) }}"
+    normal_path: "{{ output_path }}/{{ credentials_organization | regex_replace('/', '_') }}"
+  loop: "{{ credentials_lookvar | default([]) }}"
+  loop_control:
+    index_var: current_credential_index
+    loop_var: current_credential
 ...

--- a/roles/filetree_create/templates/controller_credential_input_sources.j2
+++ b/roles/filetree_create/templates/controller_credential_input_sources.j2
@@ -1,0 +1,15 @@
+{% if first_credential_input_source | default(true) | bool %}
+---
+controller_credential_input_sources:
+{% endif %}
+{% for input_source in credential_input_sources_lookvar %}
+  - target_credential: {{ current_credential['name'] }}
+    source_credential: {{ input_source['summary_fields']['source_credential']['name'] }}
+    input_field_name: {{ input_source['input_field_name'] }}
+    description: {{ input_source['description']}}
+    metadata:
+{{ input_source['metadata'] | to_nice_yaml | indent(6, true) }}
+{% endfor %}
+{% if last_credential | default(true) | bool %}
+...
+{% endif %}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
Adds Credential input sources to filetree create. It seems to already exist in filetree read.

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

I have tested and receive this for normal:
```
---
controller_credential_input_sources:
  - target_credential: lookuptest @ 09:21:53
    source_credential: hashi
    description: 
    metadata:
      secret_backend: blah
      secret_key: priv
      secret_path: path/to/secret2

  - target_credential: lookuptest @ 09:21:53
    source_credential: hashi
    description: 
    metadata:
      secret_key: mykey
      secret_path: path/to/secret

...
```
```
---
controller_credential_input_sources:
  - target_credential: lookuptest
    source_credential: hashi
    description: 
    metadata:
      secret_backend: blah
      secret_key: priv
      secret_path: path/to/secret2

  - target_credential: lookuptest
    source_credential: hashi
    description: 
    metadata:
      secret_key: mykey
      secret_path: path/to/secret

...
```

and this for flattened:
```
---
controller_credential_input_sources:
  - target_credential: lookuptest
    source_credential: hashi
    input_field_name: become_password
    description: 
    metadata:
      secret_backend: blah
      secret_key: priv
      secret_path: path/to/secret2
  - target_credential: lookuptest
    source_credential: hashi
    input_field_name: password
    description: 
    metadata:
      secret_key: mykey
      secret_path: path/to/secret
  - target_credential: lookuptest @ 09:21:53
    source_credential: hashi
    input_field_name: become_password
    description: 
    metadata:
      secret_backend: blah
      secret_key: priv
      secret_path: path/to/secret2
  - target_credential: lookuptest @ 09:21:53
    source_credential: hashi
    input_field_name: password
    description: 
    metadata:
      secret_key: mykey
      secret_path: path/to/secret
...
```

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #78 

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
