### PR TITLE
Update controller_inventories.j2

### DIFF
--- a/roles/filetree_create/templates/controller_inventories.j2
+++ b/roles/filetree_create/templates/controller_inventories.j2
@@ -69,7 +69,7 @@ controller_inventories:
 {% set _input_inventories = template_overrides_resources.inventory[current_inventories_asset_value.name].input_inventories
                               | default(template_overrides_global.inventory.input_inventories)
                               | default(query(controller_api_plugin, current_inventories_asset_value.related.input_inventories,
-                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs))
+                                              host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs))
 -%}
 {%   if _input_inventories | length > 0 %}
     input_inventories:
@@ -84,7 +84,7 @@ controller_inventories:
 {% set _instance_groups = template_overrides_resources.inventory[current_inventories_asset_value.name].instance_groups
                               | default(template_overrides_global.inventory.instance_groups)
                               | default(query(controller_api_plugin, current_inventories_asset_value.related.instance_groups,
-                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs))
+                                              host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs))
 -%}
 {%   if _instance_groups | length > 0 %}
     instance_groups:


### PR DESCRIPTION
Incorrect variable names, controller to aap

<!--- markdownlint-disable MD041 -->
# What does this PR do?

Updates variable names to match those in all the other templates, as well as whats documented to use in the kick off playbook.  Could not find any other instances of 'controller_', all other templates are 'aap_'.

This causes an exception on /etc/ansible/extended/aap_configuration_extended-devel/roles/filetree_create/tasks/controller_inventories.yml:

`"msg": "AnsibleError: An unhandled exception occurred while running the lookup plugin 'ansible.controller.controller_api'. Error was a <class 'ansible.errors.AnsibleError'> original message: Unhandled exception when retrieving verify_ssl:\n'controller_validate_certs' is undefined.`

# How should this be tested?
Defining aap_hostname, aap_validate_certs and aap_oauthtoken in the playbook, similar to how the example is shown in this repo. Once the run gets to the inventory part you see it collect all inventory information successfully. But once it's template time regarding flatten_output is where this bad template comes into play.

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #[number]

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
