### PR TITLE
Fixed typos in 'controller_inventories.j2' template

### DIFF
--- a/changelogs/fragments/filetree_create_corrected_controller_inventories_vars.yml
+++ b/changelogs/fragments/filetree_create_corrected_controller_inventories_vars.yml
@@ -1,0 +1,3 @@
+---
+minor changes:
+  - Corrected th4e following vars; controller_hostname, controller_oauthtoken, and controller_validate_certs

--- a/roles/filetree_create/templates/controller_inventories.j2
+++ b/roles/filetree_create/templates/controller_inventories.j2
@@ -69,7 +69,7 @@ controller_inventories:
 {% set _input_inventories = template_overrides_resources.inventory[current_inventories_asset_value.name].input_inventories
                               | default(template_overrides_global.inventory.input_inventories)
                               | default(query(controller_api_plugin, current_inventories_asset_value.related.input_inventories,
-                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs))
+                                              host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs))
 -%}
 {%   if _input_inventories | length > 0 %}
     input_inventories:
@@ -84,7 +84,7 @@ controller_inventories:
 {% set _instance_groups = template_overrides_resources.inventory[current_inventories_asset_value.name].instance_groups
                               | default(template_overrides_global.inventory.instance_groups)
                               | default(query(controller_api_plugin, current_inventories_asset_value.related.instance_groups,
-                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs))
+                                              host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs))
 -%}
 {%   if _instance_groups | length > 0 %}
     instance_groups:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Under roles/filetree_create/templates/controller_inventories.j2 I found incorrect variable named using the word 'controller' versus 'aap'. This breaks the filetree_create process.

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
Not that I could find.
resolves #[number]

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
