### PR TITLE
Add inventory_source to constructed inventory  

### DIFF
--- a/changelogs/fragments/filetree_create_24.yml
+++ b/changelogs/fragments/filetree_create_24.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - filetree_create - Corrected th4e following vars; controller_hostname, controller_oauthtoken, and controller_validate_certs
+minor_changes:
+  - Constructed inventories now produce an inventory source which can be used to control items such as limit and source_vars for the constructed inventory

--- a/changelogs/fragments/filetree_create_24.yml
+++ b/changelogs/fragments/filetree_create_24.yml
@@ -3,3 +3,4 @@ bugfixes:
   - filetree_create - Corrected th4e following vars; controller_hostname, controller_oauthtoken, and controller_validate_certs
 minor_changes:
   - Constructed inventories now produce an inventory source which can be used to control items such as limit and source_vars for the constructed inventory
+...

--- a/roles/filetree_create/tasks/controller_constructed_inventories.yml
+++ b/roles/filetree_create/tasks/controller_constructed_inventories.yml
@@ -55,7 +55,7 @@
         line: ''
         state: absent
 
-- name: "Block for to generate the filetre_create normal output"
+- name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
     - name: "Create the <ORGANIZATION_NAME>/controller_inventories output directory for inventories in {{ output_path }}"
@@ -85,4 +85,26 @@
       loop_control:
         loop_var: current_inventories_asset_value
         label: "{{ __dest }}"
+
+- name: "Set the constructed inventory's inventory source"
+  ansible.builtin.include_tasks: "controller_inventory_sources.yml"
+  when: not skip_inventory_sources
+  vars:
+    inventory_organization: "{{ current_inventory_sources.summary_fields.organization.name | default(organization) }}"
+    inventory_name: "{{ current_inventory_sources.name | regex_replace('/', '_') }}"
+    inventory_sources_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/controller_inventories/' + inventory_name | regex_replace('/', '_'))
+                                      if (flatten_output is not defined or (flatten_output | bool) == false)
+                                      else
+                                        output_path + '/inventory_sources.yaml' }}"
+    current_inventory_sources_asset_value: "{{ query(controller_api_plugin, current_inventory_sources.related.inventory_sources,
+                                                    host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs,
+                                                    return_all=true, max_objects=query_controller_api_max_objects)
+                                            }}"
+    last_inventory: "{{ current_inventory_index == ((inventory_lookvar | length) - 1) }}"
+  loop: "{{ constructed_inventory_lookvar }}"
+  loop_control:
+    index_var: current_inventory_index
+    loop_var: current_inventory_sources
+    label: "{{ inventory_sources_output_path }}"
+  no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 ...

--- a/roles/filetree_create/templates/controller_inventories.j2
+++ b/roles/filetree_create/templates/controller_inventories.j2
@@ -69,7 +69,7 @@ controller_inventories:
 {% set _input_inventories = template_overrides_resources.inventory[current_inventories_asset_value.name].input_inventories
                               | default(template_overrides_global.inventory.input_inventories)
                               | default(query(controller_api_plugin, current_inventories_asset_value.related.input_inventories,
-                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs))
+                                              host=aap_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs))
 -%}
 {%   if _input_inventories | length > 0 %}
     input_inventories:
@@ -84,12 +84,12 @@ controller_inventories:
 {% set _instance_groups = template_overrides_resources.inventory[current_inventories_asset_value.name].instance_groups
                               | default(template_overrides_global.inventory.instance_groups)
                               | default(query(controller_api_plugin, current_inventories_asset_value.related.instance_groups,
-                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs))
+                                              host=aap_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs))
 -%}
 {%   if _instance_groups | length > 0 %}
     instance_groups:
-{%    for _input_inventory in _instance_groups %}
-      - {{ _input_inventory.name }}
+{%    for _instance_group in _instance_groups %}
+      - {{ _instance_group.name }}
 {%    endfor %}
 {%   endif %}
 {% endif %}

--- a/roles/filetree_create/templates/controller_inventory_sources.j2
+++ b/roles/filetree_create/templates/controller_inventory_sources.j2
@@ -10,10 +10,23 @@ controller_inventory_sources:
 {% if inventory_source.summary_fields.organization is defined %}
     organization: "{{ inventory_source.summary_fields.organization.name }}"
 {% endif %}
+{% set _source_type = template_overrides_resources.inventory_source[inventory_source.name].source
+                | default(template_overrides_global.inventory_source.source)
+                | default(inventory_source.source)
+                | default('ToDo: The source of the inventory_source was originally missing and must be specified', true) %}
+{% if _source_type != 'constructed' %}
     source: "{{ template_overrides_resources.inventory_source[inventory_source.name].source
                 | default(template_overrides_global.inventory_source.source)
                 | default(inventory_source.source)
                 | default('ToDo: The source of the inventory_source was originally missing and must be specified', true) }}"
+{% endif %}
+{% if template_overrides_resources.inventory_source[inventory_source.name].limit is defined
+      or template_overrides_global.inventory_source.limit is defined
+      or inventory_source.limit is defined %}
+    limit: "{{ template_overrides_resources.inventory_source[inventory_source.name].limit
+                     | default(template_overrides_global.inventory_source.limit)
+                     | default(inventory_source.limit) }}"
+{% endif %}
 {% if template_overrides_resources.inventory_source[inventory_source.name].source_project is defined
       or template_overrides_global.inventory_source.source_project is defined
       or (inventory_source.source_project is defined and inventory_source.source_project != None) %}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
Allows the constructed inventory to have its implicit inventory_source


# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
Run with
```
input_tag:
  - controller_inventories
```
and see that an inventory source now shows for a constructed inventory and that the limit etc. can be seen there.
# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves https://github.com/redhat-cop/infra.controller_configuration/issues/24

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
duplicate of https://github.com/redhat-cop/infra.controller_configuration/pull/32
