### PR TITLE
update default filetree-read user path

### DIFF
--- a/changelogs/fragments/filetree_read_default_user_path.yml
+++ b/changelogs/fragments/filetree_read_default_user_path.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - ⚠️ BREAKING - filetree_read default var updated to align with new aap_users — may break old user definitions if they're using default path for users definition.  
+  - BREAKING - filetree_read default var updated to align with new aap_users — may break old user definitions if they're using default path for users definition.  
 ...

--- a/changelogs/fragments/filetree_read_default_user_path.yml
+++ b/changelogs/fragments/filetree_read_default_user_path.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - filetree_read update default var for users to fit with new aap_users definition
+...

--- a/changelogs/fragments/filetree_read_default_user_path.yml
+++ b/changelogs/fragments/filetree_read_default_user_path.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - filetree_read update default var for users to fit with new aap_users definition
+  - ⚠️ BREAKING: filetree_read default var updated to align with new aap_users — may break old user definitions if they're using default path for users definition.
 ...

--- a/changelogs/fragments/filetree_read_default_user_path.yml
+++ b/changelogs/fragments/filetree_read_default_user_path.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - BREAKING - filetree_read default var updated to align with new aap_users — may break old user definitions if they're using default path for users definition.  
+  - BREAKING - filetree_read default var updated to align with new aap_users — may break old user definitions if they're using default path for users definition.
 ...

--- a/changelogs/fragments/filetree_read_default_user_path.yml
+++ b/changelogs/fragments/filetree_read_default_user_path.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - BREAKING: filetree_read default var updated to align with new aap_users — may break old user definitions if they're using default path for users definition.
+  - ⚠️ BREAKING - filetree_read default var updated to align with new aap_users — may break old user definitions if they're using default path for users definition.  
 ...

--- a/changelogs/fragments/filetree_read_default_user_path.yml
+++ b/changelogs/fragments/filetree_read_default_user_path.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - ⚠️ BREAKING: filetree_read default var updated to align with new aap_users — may break old user definitions if they're using default path for users definition.
+  - BREAKING: filetree_read default var updated to align with new aap_users — may break old user definitions if they're using default path for users definition.
 ...

--- a/roles/filetree_read/README.md
+++ b/roles/filetree_read/README.md
@@ -21,7 +21,7 @@ The following Variables set the organization where should be applied the configu
 |`filetree_controller_settings`|String/List(String)|{{ dir_orgs_vars }}/{{ orgs }}/env/{{ env }}/controller_settings.d/|no|Directory path to load controller object variables|
 |`filetree_aap_organizations`|String/List(String)|{{ dir_orgs_vars }}/{{ orgs }}/env/common/aap_organizations.d/|no|Directory path to load controller object variables|
 |`filetree_controller_labels`|String/List(String)|{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_labels.d/|no|Directory path to load controller object variables|
-|`filetree_aap_user_accounts`|String/List(String)|{{ dir_orgs_vars }}/{{ orgs }}/env/{{ env }}/controller_users.d/|no|Directory path to load controller object variables|
+|`filetree_aap_user_accounts`|String/List(String)|{{ dir_orgs_vars }}/{{ orgs }}/env/{{ env }}/aap_users.d/|no|Directory path to load controller object variables|
 |`filetree_aap_teams`|String/List(String)|{{ dir_orgs_vars }}/{{ orgs }}/env/common/aap_teams.d/|no|Directory path to load controller object variables|
 |`filetree_controller_credential_types`|String/List(String)|{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_credential_types.d/|no|Directory path to load controller object variables|
 |`filetree_controller_credentials`|String/List(String)|{{ dir_orgs_vars }}/{{ orgs }}/env/{{ env }}/controller_credentials.d/|no|Directory path to load controller object variables|
@@ -198,7 +198,7 @@ orgs_vars/Organization1
     │   │   ├── app-example
     │   │   │   └── controller_instance_groups_otlc.yml
     │   │   └── controller_instance_groups.yml
-    │   ├── controller_users.d
+    │   ├── app_users.d
     │   │   ├── app-demo
     │   │   │   ├── aap_user_accounts_org1.yml
     │   │   │   └── aap_user_accounts_org2.yml
@@ -246,7 +246,7 @@ orgs_vars/Organization1
         │   ├── app-example
         │   │   └── controller_instance_groups_otlc.yml
         │   └── controller_instance_groups.yml
-        ├── controller_users.d
+        ├── aap_users.d
         │   ├── app-demo
         │   │   ├── aap_user_accounts_org1.yml
         │   │   └── aap_user_accounts_org2.yml

--- a/roles/filetree_read/defaults/main.yml
+++ b/roles/filetree_read/defaults/main.yml
@@ -33,7 +33,7 @@ controller_roles: []
 filetree_controller_settings: "{{ dir_orgs_vars }}/{{ orgs }}/env/{{ env }}/controller_settings.d/"
 filetree_aap_organizations: "{{ dir_orgs_vars }}/{{ orgs }}/env/common/aap_organizations.d/"
 filetree_controller_labels: "{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_labels.d/"
-filetree_aap_user_accounts: "{{ dir_orgs_vars }}/{{ orgs }}/env/{{ env }}/controller_users.d/"
+filetree_aap_user_accounts: "{{ dir_orgs_vars }}/{{ orgs }}/env/{{ env }}/aap_users.d/"
 filetree_aap_teams: "{{ dir_orgs_vars }}/{{ orgs }}/env/common/aap_teams.d/"
 filetree_controller_credential_types: "{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_credential_types.d/"
 filetree_controller_credentials: "{{ dir_orgs_vars }}/{{ orgs }}/env/{{ env }}/controller_credentials.d/"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
fix default path for user definition in filetree-read role



