### PR TITLE
fix: Use correct API endpoint when connecting to AAP 2.5

### DIFF
--- a/changelogs/fragments/137-fix-use_correct_api_endpoint_superuser
+++ b/changelogs/fragments/137-fix-use_correct_api_endpoint_superuser
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Use correct API endpoint when connecting to AAP 2.5 when determining super user privileges
+...

--- a/roles/object_diff/tasks/instance_groups.yml
+++ b/roles/object_diff/tasks/instance_groups.yml
@@ -1,9 +1,7 @@
 ---
-- name: "Get the current controller user to determine if it is super-admin"
-  ansible.builtin.set_fact:
-    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'api/gateway/' + gateway_api_version + '/me',
-                                                             host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs)
-                                                   }}"
+- name: "Include tasks to check if user is a superuser"
+  ansible.builtin.include_tasks:
+    file: 'superuser_check.yml'
 
 - name: "Instance Group differences (block)"
   when:

--- a/roles/object_diff/tasks/main.yml
+++ b/roles/object_diff/tasks/main.yml
@@ -51,9 +51,10 @@
             msg: "Using the 'controller_role' plugin from: {{ controller_role_plugin }}"
 
 - name: "Retrieve Ansible Tower or Automation Platform version"
-  ansible.builtin.set_fact:
-    is_aap: "{{ (aap_version is version('4.0.0', '>=')) | ansible.builtin.ternary(true, false) }}"
-    has_gateway: "{{ (aap_version is version('4.6.0', '>=')) | ansible.builtin.ternary(true, false) }}"
+  ansible.builtin.assert:
+    that:
+      - "aap_version is version('4.6.0', '>=')"
+    fail_msg: "This role is only supported on AAP 2.5+"
   vars:
     aap_version: >-
       {{

--- a/roles/object_diff/tasks/main.yml
+++ b/roles/object_diff/tasks/main.yml
@@ -54,7 +54,7 @@
   ansible.builtin.assert:
     that:
       - "aap_version is version('4.6.0', '>=')"
-    fail_msg: "This role is only supported on AAP 2.5+"
+    fail_msg: "This role is only supported on AAP 2.5+. Use infra.controller_configuration.object_diff for earlier AAP/Ansible Tower versions."
   vars:
     aap_version: >-
       {{

--- a/roles/object_diff/tasks/main.yml
+++ b/roles/object_diff/tasks/main.yml
@@ -50,14 +50,21 @@
           ansible.builtin.debug:
             msg: "Using the 'controller_role' plugin from: {{ controller_role_plugin }}"
 
-- name: "Check if the connection is to an Ansible Tower or to Automation Platform"
+- name: "Retrieve Ansible Tower or Automation Platform version"
   ansible.builtin.set_fact:
-    is_aap: "{{ lookup(controller_api_plugin, 'ping',
-                       host=aap_hostname, oauth_token=aap_oauthtoken,
-                       verify_ssl=aap_validate_certs).version is version('4.0.0', '>=') }}"
-  no_log: "{{ controller_configuration_object_diff_secure_logging }}"
-  tags:
-    - always
+    is_aap: "{{ (aap_version is version('4.0.0', '>=')) | ansible.builtin.ternary(true, false) }}"
+    has_gateway: "{{ (aap_version is version('4.6.0', '>=')) | ansible.builtin.ternary(true, false) }}"
+  vars:
+    aap_version: >-
+      {{
+        lookup(
+          controller_api_plugin,
+          'ping',
+          host=aap_hostname,
+          oauth_token=aap_oauthtoken,
+          verify_ssl=aap_validate_certs
+        ).version
+      }}
 
 - name: "Include Tasks to get OBJECT DIFF"
   ansible.builtin.include_tasks: "{{ __task_diff.name }}.yml"

--- a/roles/object_diff/tasks/organizations.yml
+++ b/roles/object_diff/tasks/organizations.yml
@@ -1,10 +1,7 @@
 ---
-- name: "Get the current controller user to determine if it is super-admin"
-  ansible.builtin.set_fact:
-    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'api/gateway/' + gateway_api_version + '/me',
-                                                              host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs)
-                                                   }}"
-  no_log: "{{ controller_configuration_object_diff_secure_logging }}"
+- name: "Include tasks to check if user is a superuser"
+  ansible.builtin.include_tasks:
+    file: 'superuser_check.yml'
 
 - name: "Role differences (block)"
   when:

--- a/roles/object_diff/tasks/roles.yml
+++ b/roles/object_diff/tasks/roles.yml
@@ -1,10 +1,7 @@
 ---
-- name: "Get the current controller user to determine if it is super-admin"
-  ansible.builtin.set_fact:
-    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'api/gateway/' + gateway_api_version + '/me',
-                                                             host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs)
-                                                   }}"
-  no_log: "{{ controller_configuration_object_diff_secure_logging }}"
+- name: "Include tasks to check if user is a superuser"
+  ansible.builtin.include_tasks:
+    file: 'superuser_check.yml'
 
 - name: "Role differences (block)"
   when:

--- a/roles/object_diff/tasks/superuser_check.yml
+++ b/roles/object_diff/tasks/superuser_check.yml
@@ -1,0 +1,24 @@
+---
+- name: "Get the current controller user to determine if it is super-admin"
+  ansible.builtin.set_fact:
+    __controller_api_current_user_check_is_admin: >-
+      {{
+        lookup(
+          (has_gateway) |
+          ansible.builtin.ternary(
+            'ansible.platform.gateway_api',
+            controller_api_plugin
+          ),
+          (has_gateway) |
+          ansible.builtin.ternary(
+            'api/gateway/' ~ gateway_api_version,
+            'api/' ~ controller_api_version,
+          ) ~ 
+          '/me',
+          host=aap_hostname,
+          oauth_token=aap_oauthtoken,
+          verify_ssl=aap_validate_certs
+        )
+      }}
+  no_log: "{{ controller_configuration_object_diff_secure_logging }}"
+...

--- a/roles/object_diff/tasks/superuser_check.yml
+++ b/roles/object_diff/tasks/superuser_check.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Get the current controller user to determine if it is super-admin"
+- name: "Get the current controller user to determine if the user is a super-admin"
   ansible.builtin.set_fact:
     __controller_api_current_user_check_is_admin: >-
       {{

--- a/roles/object_diff/tasks/superuser_check.yml
+++ b/roles/object_diff/tasks/superuser_check.yml
@@ -4,17 +4,8 @@
     __controller_api_current_user_check_is_admin: >-
       {{
         lookup(
-          (has_gateway) |
-          ansible.builtin.ternary(
-            'ansible.platform.gateway_api',
-            controller_api_plugin
-          ),
-          (has_gateway) |
-          ansible.builtin.ternary(
-            'api/gateway/' ~ gateway_api_version,
-            'api/' ~ controller_api_version,
-          ) ~ 
-          '/me',
+          'ansible.platform.gateway_api',
+          'api/gateway/' ~ gateway_api_version ~ '/me',
           host=aap_hostname,
           oauth_token=aap_oauthtoken,
           verify_ssl=aap_validate_certs

--- a/roles/object_diff/tasks/teams.yml
+++ b/roles/object_diff/tasks/teams.yml
@@ -1,10 +1,7 @@
 ---
-- name: "Get the current controller user to determine if it is super-admin"
-  ansible.builtin.set_fact:
-    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'api/gateway/' + gateway_api_version + '/me',
-                                                             host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs)
-                                                   }}"
-  no_log: "{{ controller_configuration_object_diff_secure_logging }}"
+- name: "Include tasks to check if user is a superuser"
+  ansible.builtin.include_tasks:
+    file: 'superuser_check.yml'
 
 - name: "Team differences (block)"
   when:

--- a/roles/object_diff/tasks/user_accounts.yml
+++ b/roles/object_diff/tasks/user_accounts.yml
@@ -1,11 +1,7 @@
 ---
-# tasks file for controller_ldap_settings
-- name: "Get the current controller user to determine if it is super-admin"
-  ansible.builtin.set_fact:
-    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'api/gateway/' + gateway_api_version + '/me',
-                                                             host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs)
-                                                   }}"
-  no_log: "{{ controller_configuration_object_diff_secure_logging }}"
+- name: "Include tasks to check if user is a superuser"
+  ansible.builtin.include_tasks:
+    file: 'superuser_check.yml'
 
 - name: "Get all users from the API"
   ansible.builtin.set_fact:


### PR DESCRIPTION
<!--- markdownlint-disable -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
This PR resolves an issue where the incorrect API endpoint would be used when checking the user privileges when connecting to AAP 2.5.
The relevant API endpoint moved to Gateway.
Additionally, I've split out the super user check into its own file (`superuser_check.yml`) as the code was 100% identical across those files touched.

Note:
I've used my own style for writing Ansible; if that's not fine, I am happy to refactor it based on the current (in my opinion rather unreadable) Ansible style.

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
This should be picked up automatically by existing CI.

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #[number]
No

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
