### PR TITLE
credentials when using secrets_as_variables:

### DIFF
--- a/roles/filetree_create/templates/controller_credentials.j2
+++ b/roles/filetree_create/templates/controller_credentials.j2
@@ -20,7 +20,7 @@ controller_credentials:
 {%     if show_encrypted is defined and show_encrypted %}
       {{ input.key }}: {{ input.value }}
 {%     elif secrets_as_variables is defined and secrets_as_variables %}
-      {{ input.key }}: {{ input.value | replace("$encrypted$", "\"{{ " + secrets_as_variables_prefix + "_controller_credentials_" + (current_credentials_asset_value.name | replace(' ', '_') | lower) + "_" + (input.key | replace(' ', '_') | lower) + " }}\"") }}
+      {{ input.key }}: {{ input.value | replace("$encrypted$", "\"{{ " + secrets_as_variables_prefix + "_controller_credentials_" + (current_credentials_asset_value.name | lower | regex_replace('[^a-z0-9]','_') + "_" + (input.key | lower | regex_replace('[^a-z0-9]', '_')) + " | default('$encrypted$') }}\"") }}
 {%     else %}
       {{ input.key }}: {{ input.value | replace("$encrypted$", "\'\'") }}
 {%     endif %}

--- a/roles/filetree_create/templates/controller_credentials.j2
+++ b/roles/filetree_create/templates/controller_credentials.j2
@@ -20,7 +20,7 @@ controller_credentials:
 {%     if show_encrypted is defined and show_encrypted %}
       {{ input.key }}: {{ input.value }}
 {%     elif secrets_as_variables is defined and secrets_as_variables %}
-      {{ input.key }}: {{ input.value | replace("$encrypted$", "\"{{ " + secrets_as_variables_prefix + "_controller_credentials_" + (current_credentials_asset_value.name | lower | regex_replace('[^a-z0-9]','_') + "_" + (input.key | lower | regex_replace('[^a-z0-9]', '_')) + " | default('$encrypted$') }}\"") }}
+      {{ input.key }}: {{ input.value | replace("$encrypted$", "\"{{ " + secrets_as_variables_prefix + "_controller_credentials_" + (current_credentials_asset_value.name | lower | regex_replace('[^a-z0-9]','_')) + "_" + (input.key | lower | regex_replace('[^a-z0-9]', '_')) + " | default('$encrypted$') }}\"") }}
 {%     else %}
       {{ input.key }}: {{ input.value | replace("$encrypted$", "\'\'") }}
 {%     endif %}

--- a/roles/filetree_create/templates/eda_credentials.j2
+++ b/roles/filetree_create/templates/eda_credentials.j2
@@ -23,7 +23,7 @@ eda_credentials:
 {%     if show_encrypted is defined and show_encrypted %}
       {{ input.key }}: {{ input.value }}
 {%     elif secrets_as_variables is defined and secrets_as_variables %}
-      {{ input.key }}: {{ input.value | replace("$encrypted$", "\"{{ " + secrets_as_variables_prefix + "_eda_credentials_" + (eda_credential.name | replace(' ', '_') | lower) + "_" + (input.key | replace(' ', '_') | lower) + " }}\"") }}
+      {{ input.key }}: {{ input.value | replace("$encrypted$", "\"{{ " + secrets_as_variables_prefix + "_eda_credentials_" + (eda_credential.name | lower | regex_replace('[^a-z0-9]','_')) + "_" + (input.key | lower | regex_replace('[^a-z0-9]','_')) + " | default('$encrypted$') }}\"") }}
 {%     else %}
       {{ input.key }}: {{ input.value | replace("$encrypted$", "\'\'") }}
 {%     endif %}


### PR DESCRIPTION
- also replace other non valid characters with underscore
- add a default to '$encrypted$' if variable is not set

# What does this PR do?
When using secrets_as_variables fix the name of the variable and add a default value

## How should this be tested?
add a credential with a name containing special characters like '.', '/' or '-' and see if it gets replaced correctly

## Is there a relevant Issue open for this?
N/A

## Other Relevant info, PRs, etc
enhances #121