### PR TITLE
Fix adding divider between job templates list

### DIFF
--- a/roles/filetree_create/templates/controller_job_templates.j2
+++ b/roles/filetree_create/templates/controller_job_templates.j2
@@ -262,6 +262,6 @@ controller_templates:
                                         | default(template_overrides_global.job_template.prevent_instance_group_fallback)
                                         | default(current_job_templates_asset_value.prevent_instance_group_fallback | bool | lower) }}
 {% endif %}
-{% if last_job_template | default(true) | bool | lower %}
+{% if last_job_template | default(true) | bool %}
 ...
 {% endif %}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Fixes an issue with the filetree_create role adding a `...` separate between each item in the job templates list.

## How should this be tested?
Normal testing.

## Is there a relevant Issue open for this?
#151 

## Other Relevant info, PRs, etc
Similar to https://github.com/redhat-cop/infra.controller_configuration/pull/66