### PR TITLE
Fixed playbook failing if EDA credential's value is null

### DIFF
--- a/roles/filetree_create/templates/eda_decision_environments.j2
+++ b/roles/filetree_create/templates/eda_decision_environments.j2
@@ -9,8 +9,10 @@ eda_decision_environments:
     organization: "{{ (query('ansible.platform.gateway_api', 'api/eda/v1/organizations/',
                             host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs,
                             return_all=true, max_objects=query_eda_api_max_objects) | selectattr('id', 'equalto', eda_decision_environment.organization_id) | first).name }}"
+{%   if eda_decision_environment.eda_credential_id is not none %}
     eda_credential: "{{ (query('ansible.platform.gateway_api', 'api/eda/v1/eda-credentials/',
                             host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs,
                             return_all=true, max_objects=query_eda_api_max_objects) | selectattr('id', 'equalto', eda_decision_environment.eda_credential_id) | first).name }}"
+{%   endif %}
 {% endfor %}
 ...


### PR DESCRIPTION
<!--- markdownlint-disable -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->

This PR fixes an issue where the role `infra.aap_configuration_extended.filetree_create` fails if an EDA decision environment has a credential with value `null`.

## How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

- Create a decision environment in AAP without specifying credentials
- Run the role `infra.aap_configuration_extended.filetree_create` with the input tag as `all`, `eda`, or `eda_decision_environments`
- The role will complete successfully where as previously the role fails at the task `Add current EDA decision_environments to the eda_decision_environments.yaml output file in ./filetree_output` with the following error:

```bash
TASK [infra.aap_configuration_extended.filetree_create : Add current EDA decision_environments to the eda_decision_environments.yaml output file in ./filetree_output] ***
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: No first item, sequence was empty.. No first item, sequence was empty.
fatal: [localhost]: FAILED! =>
    changed: false
    msg: 'AnsibleUndefinedVariable: No first item, sequence was empty.. No first item,
        sequence was empty.'
```

## Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

## Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->

My setup:
infra.aap_configuration v3.7.0
infra.aap_configuration_extended v3.0.1

AAP Controller 4.6.18
AAP EDA 1.1.11
AAP Hub 4.10.6