### PR TITLE
Fixed yaml block scalar not being properly formatted in generated controller credential files

### DIFF
--- a/roles/filetree_create/templates/controller_credentials.j2
+++ b/roles/filetree_create/templates/controller_credentials.j2
@@ -17,7 +17,10 @@ controller_credentials:
     inputs:
 {%   for input in (template_overrides_resources.credential[current_credentials_asset_value.name].inputs |
                    default(current_credentials_asset_value.inputs)) | dict2items %}
-{%     if show_encrypted is defined and show_encrypted %}
+{%     if input.value is string and '\n' in input.value %}
+      {{ input.key }}: |-
+        {{ input.value | indent(width=8) }}
+{%     elif show_encrypted is defined and show_encrypted %}
       {{ input.key }}: {{ input.value }}
 {%     elif secrets_as_variables is defined and secrets_as_variables %}
       {{ input.key }}: {{ input.value | replace("$encrypted$", "\"{{ " + secrets_as_variables_prefix + "_controller_credentials_" + (current_credentials_asset_value.name | lower | regex_replace('[^a-z0-9]','_')) + "_" + (input.key | lower | regex_replace('[^a-z0-9]', '_')) + " | default('$encrypted$') }}\"") }}


### PR DESCRIPTION
<!--- markdownlint-disable -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->

This PR fixes an issue where the generated file for a controller credential, which has a multiline input field, would have messed up block scalar format.

Since multiline fields have more than 1 line, I imagine that we only need to detect at most 1 `\n` in the value before concluding that it's multiline type.

## How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

- Create a test controller credential in AAP of one of the following types:
  - CyberArk Central Credential Provider Lookup
  - CyberArk Conjur Secrets Manager Lookup
  - GitHub App Installation Access Token Lookup
  - GPG Public Key
  - Google Compute Engine
  - HashiCorp Vault Secret Lookup
  - HashiCorp Vault Signed SSH
  - Terraform backend configuration
- I used HashiCorp Vault Secret Lookup
- Put in a random data in PEM format in one of the multiline fields (Ca Certificate for me). I got this from google searches
```bash
-----BEGIN CERTIFICATE-----
MIIEaTCCA1GgAwIBAgILBAAAAAABRE7wQkcwDQYJKoZIhvcNAQELBQAwVzELMAkG
C33JiJ1Pi/D4nGyMVTXbv/Kz6vvjVudKRtkTIso21ZvBqOOWQ5PyDLzm+ebomchj
SHh/VzZpGhkdWtHUfcKc1H/hgBKueuqI6lfYygoKOhJJomIZeg0k9zfrtHOSewUj
...
dHBzOi8vd3d3Lmdsb2JhbHNpZ24uY29tL3JlcG9zaXRvcnkvMDMGA1UdHwQsMCow
KKAmoCSGImh0dHA6Ly9jcmwuZ2xvYmFsc2lnbi5uZXQvcm9vdC5jcmwwPQYIKwYB
K1pp74P1S8SqtCr4fKGxhZSM9AyHDPSsQPhZSZg=
-----END CERTIFICATE-----
```
- Run the role `infra.aap_configuration_extended.filetree_create` with the input tag as `all`, `controller`, or `controller_credentials`
- Notice that the last task "Re-write all the generated files to make them more readable" will show "changed" or "ok" where as previously it would fail when trying to modify the generated file for the test controller credential with the error
```bash
    stderr: 'Error: bad file ''filetree_output/<org>/controller_credentials/2_test_credentail.yaml'': yaml: line 10: could not find expected
        '':'''
```
- The previously generated file will look something like this
```yaml
---
controller_credentials:
  - name: "Test credential"
    ...
    inputs:
      ...
      cacert: -----BEGIN CERTIFICATE-----
MIIEaTCCA1GgAwIBAgILBAAAAAABRE7wQkcwDQYJKoZIhvcNAQELBQAwVzELMAkG
C33JiJ1Pi/D4nGyMVTXbv/Kz6vvjVudKRtkTIso21ZvBqOOWQ5PyDLzm+ebomchj
SHh/VzZpGhkdWtHUfcKc1H/hgBKueuqI6lfYygoKOhJJomIZeg0k9zfrtHOSewUj
...
dHBzOi8vd3d3Lmdsb2JhbHNpZ24uY29tL3JlcG9zaXRvcnkvMDMGA1UdHwQsMCow
KKAmoCSGImh0dHA6Ly9jcmwuZ2xvYmFsc2lnbi5uZXQvcm9vdC5jcmwwPQYIKwYB
K1pp74P1S8SqtCr4fKGxhZSM9AyHDPSsQPhZSZg=
-----END CERTIFICATE-----
```
- Now it looks something like this:
```yaml
---
controller_credentials:
  - name: "Test credential"
    ...
    inputs:
      ...
      cacert:
        -----BEGIN CERTIFICATE-----
        MIIEaTCCA1GgAwIBAgILBAAAAAABRE7wQkcwDQYJKoZIhvcNAQELBQAwVzELMAkG
        C33JiJ1Pi/D4nGyMVTXbv/Kz6vvjVudKRtkTIso21ZvBqOOWQ5PyDLzm+ebomchj
        SHh/VzZpGhkdWtHUfcKc1H/hgBKueuqI6lfYygoKOhJJomIZeg0k9zfrtHOSewUj
        ...
        dHBzOi8vd3d3Lmdsb2JhbHNpZ24uY29tL3JlcG9zaXRvcnkvMDMGA1UdHwQsMCow
        KKAmoCSGImh0dHA6Ly9jcmwuZ2xvYmFsc2lnbi5uZXQvcm9vdC5jcmwwPQYIKwYB
        K1pp74P1S8SqtCr4fKGxhZSM9AyHDPSsQPhZSZg=
        -----END CERTIFICATE-----
```

## Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

## Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->

My setup:
infra.aap_configuration v3.7.0
infra.aap_configuration_extended v3.0.1

AAP Controller 4.6.18
AAP EDA 1.1.11
AAP Hub 4.10.6