### PR TITLE
Fixed yaml block scalar not being properly formatted in generated EDA credential files

### DIFF
--- a/roles/filetree_create/templates/eda_credentials.j2
+++ b/roles/filetree_create/templates/eda_credentials.j2
@@ -5,29 +5,30 @@ eda_credentials:
     description: "{{ template_overrides_resources.eda_credential[eda_credential.name].description
                      | default(template_overrides_global.eda_credential.description)
                      | default(eda_credential.description) }}"
-{% if eda_credential.credential_type is defined %}
-    credential_type:
-{{ eda_credential.credential_type | dict2items | rejectattr('key', 'equalto', 'id') | list | items2dict | to_nice_yaml(indent=2,sort_keys=False) | indent(width=6, first=True) }}
-{%- endif %}
-{% if eda_credential.organization is defined %}
-    organization:
-{{ eda_credential.organization | dict2items | rejectattr('key', 'equalto', 'id') | list | items2dict | to_nice_yaml(indent=2,sort_keys=False) | indent(width=6, first=True) }}
-{%- endif %}
-{% if eda_credential.references is defined %}
+{%   if eda_credential.credential_type is defined %}
+    credential_type: "{{ eda_credential.credential_type.name }}"
+{%   endif %}
+{%   if eda_credential.organization is defined %}
+    organization: "{{ eda_credential.organization.name }}"
+{%   endif %}
+{%   if eda_credential.references is defined %}
     references: "{{ eda_credential.references }}"
-{% endif %}
-{% if eda_credential.inputs is defined %}
+{%   endif %}
+{%   if eda_credential.inputs is defined %}
     inputs:
-{%   for input in (template_overrides_resources.eda_credential[eda_credential.name].inputs |
+{%     for input in (template_overrides_resources.eda_credential[eda_credential.name].inputs |
                    default(eda_credential.inputs)) | dict2items %}
-{%     if show_encrypted is defined and show_encrypted %}
+{%       if input.value is string and '\n' in input.value %}
+      {{ input.key }}: |-
+        {{ input.value | indent(width=8) }}
+{%       elif show_encrypted is defined and show_encrypted %}
       {{ input.key }}: {{ input.value }}
-{%     elif secrets_as_variables is defined and secrets_as_variables %}
+{%       elif secrets_as_variables is defined and secrets_as_variables %}
       {{ input.key }}: {{ input.value | replace("$encrypted$", "\"{{ " + secrets_as_variables_prefix + "_eda_credentials_" + (eda_credential.name | lower | regex_replace('[^a-z0-9]','_')) + "_" + (input.key | lower | regex_replace('[^a-z0-9]','_')) + " | default('$encrypted$') }}\"") }}
-{%     else %}
+{%       else %}
       {{ input.key }}: {{ input.value | replace("$encrypted$", "\'\'") }}
-{%     endif %}
-{%   endfor %}
-{%- endif %}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
 {% endfor %}
 ...


### PR DESCRIPTION
<!--- markdownlint-disable -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->

- Similar to #166, this PR fixes an issue where the generated file for a EDA credential, which has a multiline input field, would have messed up block scalar format.

  The last task "Re-write all the generated files to make them more readable" would fail with error
```bash
stderr: 'Error: bad file ''filetree_output/eda_credentials.yaml'': yaml: line 223:
        could not find expected '':'''
``` 

  The generated `eda_credentials.yaml` would look something like this:
```yaml
  - name: "test credential"
    description: ""
    credential_type:
      name: ECDSA Event Stream
      namespace: event_stream
      kind: ecdsa
    organization:
      name: Default
      description: The default organization for Ansible Automation Platform
    references: ""
    inputs:
      auth_type: ecdsa
      hash_algorithm: sha256
      http_header_key: test
      prefix_http_header_key: 
      public_key: -----BEGIN PGP PUBLIC KEY BLOCK-----
Comment: Bob's OpenPGP certificate
Comment: https://www.ietf.org/id/draft-bre-openpgp-samples-01.html

mQGNBF2lnPIBDAC5cL9PQoQLTMuhjbYvb4Ncuuo0bfmgPRFywX53jPhoFf4Zg6mv
/seOXpgecTdOcVttfzC8ycIKrt3aQTiwOG/ctaR4Bk/t6ayNFfdUNxHWk4WCKzdz
/56fW2O0F23qIRd8UUJp5IIlN4RDdRCtdhVQIAuzvp2oVy/LaS2kxQoKvph/5pQ/
5whqsyroEWDJoSV0yOb25B/iwk/pLUFoyhDG9bj0kIzDxrEqW+7Ba8nocQlecMF3
X5KMN5kp2zraLv9dlBBpWW43XktjcCZgMy20SouraVma8Je/ECwUWYUiAZxLIlMv
9CurEOtxUw6N3RdOtLmYZS9uEnn5y1UkF88o8Nku890uk6BrewFzJyLAx5wRZ4F0
qV/yq36UWQ0JB/AUGhHVPdFf6pl6eaxBwT5GXvbBUibtf8YI2og5RsgTWtXfU7eb
SGXrl5ZMpbA6mbfhd0R8aPxWfmDWiIOhBufhMCvUHh1sApMKVZnvIff9/0Dca3wb
vLIwa3T4CyshfT0AEQEAAbQhQm9iIEJhYmJhZ2UgPGJvYkBvcGVucGdwLmV4YW1w
bGU+iQHOBBMBCgA4AhsDBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAFiEE0aZuGiOx
gsmYD3iM+/zIKgFeczAFAl2lnvoACgkQ+/zIKgFeczBvbAv/VNk90a6hG8Od9xTz
XxH5YRFUSGfIA1yjPIVOnKqhMwps2U+sWE3urL+MvjyQRlyRV8oY9IOhQ5Esm6DO
ZYrTnE7qVETm1ajIAP2OFChEc55uH88x/anpPOXOJY7S8jbn3naC9qad75BrZ+3g
9EBUWiy5p8TykP05WSnSxNRt7vFKLfEB4nGkehpwHXOVF0CRNwYle42bg8lpmdXF
DcCZCi+qEbafmTQzkAqyzS3nCh3IAqq6Y0kBuaKLm2tSNUOlZbD+OHYQNZ5Jix7c
ZUzs6Xh4+I55NRWl5smrLq66yOQoFPy9jot/Qxikx/wP3MsAzeGaZSEPc0fHp5G1
6rlGbxQ3vl8/usUV7W+TMEMljgwd5x8POR6HC8EaCDfVnUBCPi/Gv+egLjsIbPJZ
ZEroiE40e6/UoCiQtlpQB5exPJYSd1Q1txCwueih99PHepsDhmUQKiACszNU+RRo
zAYau2VdHqnRJ7QYdxHDiH49jPK4NTMyb/tJh2TiIwcmsIpGuQGNBF2lnPIBDADW
ML9cbGMrp12CtF9b2P6z9TTT74S8iyBOzaSvdGDQY/sUtZXRg21HWamXnn9sSXvI
DEINOQ6A9QxdxoqWdCHrOuW3ofneYXoG+zeKc4dC86wa1TR2q9vW+RMXSO4uImA+
Uzula/6k1DogDf28qhCxMwG/i/m9g1c/0aApuDyKdQ1PXsHHNlgd/Dn6rrd5y2AO
baifV7wIhEJnvqgFXDN2RXGjLeCOHV4Q2WTYPg/S4k1nMXVDwZXrvIsA0YwIMgIT
86Rafp1qKlgPNbiIlC1g9RY/iFaGN2b4Ir6GDohBQSfZW2+LXoPZuVE/wGlQ01rh
827KVZW4lXvqsge+wtnWlszcselGATyzqOK9LdHPdZGzROZYI2e8c+paLNDdVPL6
vdRBUnkCaEkOtl1mr2JpQi5nTU+gTX4IeInC7E+1a9UDF/Y85ybUz8XV8rUnR76U
qVC7KidNepdHbZjjXCt8/Zo+Tec9JNbYNQB/e9ExmDntmlHEsSEQzFwzj8sxH48A
EQEAAYkBtgQYAQoAIBYhBNGmbhojsYLJmA94jPv8yCoBXnMwBQJdpZzyAhsMAAoJ
EPv8yCoBXnMw6f8L/26C34dkjBffTzMj5Bdzm8MtF67OYneJ4TQMw7+41IL4rVcS
KhIhk/3Ud5knaRtP2ef1+5F66h9/RPQOJ5+tvBwhBAcUWSupKnUrdVaZQanYmtSx
cVV2PL9+QEiNN3tzluhaWO//rACxJ+K/ZXQlIzwQVTpNhfGzAaMVV9zpf3u0k14i
tcv6alKY8+rLZvO1wIIeRZLmU0tZDD5HtWDvUV7rIFI1WuoLb+KZgbYn3OWjCPHV
dTrdZ2CqnZbG3SXw6awH9bzRLV9EXkbhIMez0deCVdeo+wFFklh8/5VK2b0vk/+w
qMJxfpa1lHvJLobzOP9fvrswsr92MA2+k901WeISR7qEzcI0Fdg8AyFAExaEK6Vy
jP7SXGLwvfisw34OxuZr3qmx1Sufu4toH3XrB7QJN8XyqqbsGxUCBqWif9RSK4xj
zRTe56iPeiSJJOIciMP9i2ldI+KgLycyeDvGoBj0HCLO3gVaBe4ubVrj5KjhX2PV
NEJd3XZRzaXZE2aAMQ==
=NXei
-----END PGP PUBLIC KEY BLOCK-----

      signature_encoding: base64
```

- I updated the data format for `credential_type` and `organization` fields to be inline with `controller_credentials` counterpart found in https://github.com/redhat-cop/aap_configuration_extended/blob/devel/roles/filetree_create/templates/controller_credentials.j2

  From the output above:
```yaml
  - name: "test credential"
    description: ""
    credential_type:
      name: ECDSA Event Stream
      namespace: event_stream
      kind: ecdsa
    organization:
      name: Default
      description: The default organization for Ansible Automation Platform
    ...
```

- I also took the liberty to indent the `if/else` statements according to the first `for` loop on top of the `eda_credentials.j2` file. Let me know if you prefer me to leave the format as is.

## How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

- Create a test EDA credential in AAP of one of the following types: 
    - ECDSA Event Stream
    - Postgres
- I used ECDSA Event Stream and put the ramdom pubkey from google in "Public_key" field
- Run the role `infra.aap_configuration_extended.filetree_create` with the input tag as `all`, `eda` or `eda_credentials`
- Notice that the last task "Re-write all the generated files to make them more readable" will now show "changed" or "ok"
- The generated file `eda_credentials.yaml` now looks something like this:
```yaml
  - name: test credential
    description: ""
    credential_type: ECDSA Event Stream
    organization: Default
    references: ""
    inputs:
      auth_type: ecdsa
      hash_algorithm: sha256
      http_header_key: test
      prefix_http_header_key:
      public_key: |-
        -----BEGIN PGP PUBLIC KEY BLOCK-----
        Comment: Bob's OpenPGP certificate
        Comment: https://www.ietf.org/id/draft-bre-openpgp-samples-01.html

        mQGNBF2lnPIBDAC5cL9PQoQLTMuhjbYvb4Ncuuo0bfmgPRFywX53jPhoFf4Zg6mv
        /seOXpgecTdOcVttfzC8ycIKrt3aQTiwOG/ctaR4Bk/t6ayNFfdUNxHWk4WCKzdz
        /56fW2O0F23qIRd8UUJp5IIlN4RDdRCtdhVQIAuzvp2oVy/LaS2kxQoKvph/5pQ/
        5whqsyroEWDJoSV0yOb25B/iwk/pLUFoyhDG9bj0kIzDxrEqW+7Ba8nocQlecMF3
        X5KMN5kp2zraLv9dlBBpWW43XktjcCZgMy20SouraVma8Je/ECwUWYUiAZxLIlMv
        9CurEOtxUw6N3RdOtLmYZS9uEnn5y1UkF88o8Nku890uk6BrewFzJyLAx5wRZ4F0
        qV/yq36UWQ0JB/AUGhHVPdFf6pl6eaxBwT5GXvbBUibtf8YI2og5RsgTWtXfU7eb
        SGXrl5ZMpbA6mbfhd0R8aPxWfmDWiIOhBufhMCvUHh1sApMKVZnvIff9/0Dca3wb
        vLIwa3T4CyshfT0AEQEAAbQhQm9iIEJhYmJhZ2UgPGJvYkBvcGVucGdwLmV4YW1w
        bGU+iQHOBBMBCgA4AhsDBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAFiEE0aZuGiOx
        gsmYD3iM+/zIKgFeczAFAl2lnvoACgkQ+/zIKgFeczBvbAv/VNk90a6hG8Od9xTz
        XxH5YRFUSGfIA1yjPIVOnKqhMwps2U+sWE3urL+MvjyQRlyRV8oY9IOhQ5Esm6DO
        ZYrTnE7qVETm1ajIAP2OFChEc55uH88x/anpPOXOJY7S8jbn3naC9qad75BrZ+3g
        9EBUWiy5p8TykP05WSnSxNRt7vFKLfEB4nGkehpwHXOVF0CRNwYle42bg8lpmdXF
        DcCZCi+qEbafmTQzkAqyzS3nCh3IAqq6Y0kBuaKLm2tSNUOlZbD+OHYQNZ5Jix7c
        ZUzs6Xh4+I55NRWl5smrLq66yOQoFPy9jot/Qxikx/wP3MsAzeGaZSEPc0fHp5G1
        6rlGbxQ3vl8/usUV7W+TMEMljgwd5x8POR6HC8EaCDfVnUBCPi/Gv+egLjsIbPJZ
        ZEroiE40e6/UoCiQtlpQB5exPJYSd1Q1txCwueih99PHepsDhmUQKiACszNU+RRo
        zAYau2VdHqnRJ7QYdxHDiH49jPK4NTMyb/tJh2TiIwcmsIpGuQGNBF2lnPIBDADW
        ML9cbGMrp12CtF9b2P6z9TTT74S8iyBOzaSvdGDQY/sUtZXRg21HWamXnn9sSXvI
        DEINOQ6A9QxdxoqWdCHrOuW3ofneYXoG+zeKc4dC86wa1TR2q9vW+RMXSO4uImA+
        Uzula/6k1DogDf28qhCxMwG/i/m9g1c/0aApuDyKdQ1PXsHHNlgd/Dn6rrd5y2AO
        baifV7wIhEJnvqgFXDN2RXGjLeCOHV4Q2WTYPg/S4k1nMXVDwZXrvIsA0YwIMgIT
        86Rafp1qKlgPNbiIlC1g9RY/iFaGN2b4Ir6GDohBQSfZW2+LXoPZuVE/wGlQ01rh
        827KVZW4lXvqsge+wtnWlszcselGATyzqOK9LdHPdZGzROZYI2e8c+paLNDdVPL6
        vdRBUnkCaEkOtl1mr2JpQi5nTU+gTX4IeInC7E+1a9UDF/Y85ybUz8XV8rUnR76U
        qVC7KidNepdHbZjjXCt8/Zo+Tec9JNbYNQB/e9ExmDntmlHEsSEQzFwzj8sxH48A
        EQEAAYkBtgQYAQoAIBYhBNGmbhojsYLJmA94jPv8yCoBXnMwBQJdpZzyAhsMAAoJ
        EPv8yCoBXnMw6f8L/26C34dkjBffTzMj5Bdzm8MtF67OYneJ4TQMw7+41IL4rVcS
        KhIhk/3Ud5knaRtP2ef1+5F66h9/RPQOJ5+tvBwhBAcUWSupKnUrdVaZQanYmtSx
        cVV2PL9+QEiNN3tzluhaWO//rACxJ+K/ZXQlIzwQVTpNhfGzAaMVV9zpf3u0k14i
        tcv6alKY8+rLZvO1wIIeRZLmU0tZDD5HtWDvUV7rIFI1WuoLb+KZgbYn3OWjCPHV
        dTrdZ2CqnZbG3SXw6awH9bzRLV9EXkbhIMez0deCVdeo+wFFklh8/5VK2b0vk/+w
        qMJxfpa1lHvJLobzOP9fvrswsr92MA2+k901WeISR7qEzcI0Fdg8AyFAExaEK6Vy
        jP7SXGLwvfisw34OxuZr3qmx1Sufu4toH3XrB7QJN8XyqqbsGxUCBqWif9RSK4xj
        zRTe56iPeiSJJOIciMP9i2ldI+KgLycyeDvGoBj0HCLO3gVaBe4ubVrj5KjhX2PV
        NEJd3XZRzaXZE2aAMQ==
        =NXei
        -----END PGP PUBLIC KEY BLOCK-----
      signature_encoding: base64
```

## Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

## Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->

My setup:
infra.aap_configuration v3.7.0
infra.aap_configuration_extended v3.0.1

AAP Controller 4.6.18
AAP EDA 1.1.11
AAP Hub 4.10.6