### PR TITLE
Fix default value for webhook_service in workflow job templates and Fix verbosity key in workflow job templates

### DIFF
--- a/changelogs/fragments/workflow_job_templates_template.yml
+++ b/changelogs/fragments/workflow_job_templates_template.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fix default value for webhook_service in workflow job templates
+  - Fix verbosity key in workflow job templates

--- a/roles/filetree_create/templates/controller_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/controller_workflow_job_templates.j2
@@ -29,7 +29,7 @@ controller_workflows:
                           return_all=true, max_objects=query_controller_api_max_objects) %}
 {%     if jt_var | length > 0 %}
 {%       if jt_var[0]['ask_verbosity_on_launch'] %}
-        verbosity = "{{ jt_var[0]['verbosity'] }}"
+        verbosity: "{{ jt_var[0]['verbosity'] }}"
 {%       endif %}
 {%     endif %}
 {%   endif %}
@@ -102,7 +102,7 @@ controller_workflows:
     ask_inventory_on_launch: {{ template_overrides_resources.workflow_job_template[current_workflow_job_templates_asset_value.name].ask_inventory_on_launch
                                 | default(template_overrides_global.workflow_job_template.ask_inventory_on_launch)
                                 | default(current_workflow_job_templates_asset_value.ask_inventory_on_launch | bool | lower) }}
-    webhook_service: "{{ template_overrides_resources.workflow_job_template[current_workflow_job_templates_asset_value.name].description
+    webhook_service: "{{ template_overrides_resources.workflow_job_template[current_workflow_job_templates_asset_value.name].webhook_service
                          | default(template_overrides_global.workflow_template.webhook_service)
                          | default(current_workflow_job_templates_asset_value.webhook_service) }}"
 {% if template_overrides_resources.workflow_job_template[current_workflow_job_templates_asset_value.name].extra_vars is defined


### PR DESCRIPTION
<!--- markdownlint-disable -->
# What does this PR do?
Fixes the default value for webhook_service and the invalid YAML for verbosity in controller_workflow_job_templates.j2

## How should this be tested?
- name: "Include filetree_create role"
  ansible.builtin.include_role:
    name: infra.aap_configuration_extended.filetree_create
  vars:
    output_path: "/tmp/output"
    input_tag:
      - controller_workflow_job_templates
    valid_tags:
      - controller_workflow_job_templates
      
      
## Is there a relevant Issue open for this?
https://github.com/redhat-cop/aap_configuration_extended/issues/175

