### PR TITLE
allow custom output folder naming when not-flat

### DIFF
--- a/changelogs/fragments/filetree_create_folders.yml
+++ b/changelogs/fragments/filetree_create_folders.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Added the ability to change the output folder names in `filetree_create`
+...

--- a/roles/filetree_create/defaults/main.yml
+++ b/roles/filetree_create/defaults/main.yml
@@ -20,6 +20,32 @@ controller_workflows: []
 # Output directory path
 output_path: "/tmp/filetree_output"
 
+# Gateway - Non-Flat Folder Names
+filetree_create_aap_applications: "aap_applications.d"
+
+# Controller - Non-Flat Folder Names
+filetree_create_controller_applications: "controller_applications.d"
+filetree_create_controller_labels: "controller_labels.d"
+filetree_create_controller_credentials: "controller_credentials.d"
+filetree_create_controller_credential_input_sources: "controller_credential_input_sources.d"
+filetree_create_controller_notifications: "controller_notification_templates.d"
+filetree_create_controller_projects: "controller_projects.d"
+filetree_create_controller_inventories: "controller_inventories.d"
+filetree_create_controller_inventory_sources: "controller_inventory_sources.d"
+filetree_create_controller_hosts: "controller_hosts.d"
+filetree_create_controller_groups: "controller_groups.d"
+filetree_create_controller_templates: "controller_job_templates.d"
+filetree_create_controller_workflow_job_templates: "controller_workflow_job_templates.d"
+filetree_create_controller_schedules: "controller_schedules.d"
+filetree_create_controller_user_accounts: "controller_users.d"
+filetree_create_controller_teams: "controller_teams.d"
+filetree_create_controller_user_roles: "controller_roles.d/user_roles.d"
+filetree_create_controller_team_roles: "controller_roles.d/team_roles.d"
+
+# EDA - Non-Flat Folder Names
+filetree_create_eda_projects: "eda_projects.d"
+filetree_create_eda_rulebook_activations: "eda_rulebook_activations.d"
+
 # Maximum number of objects to return from the list. If a list view returns more an max_objects an exception will be raised
 query_controller_api_max_objects: 10000
 query_gateway_api_max_objects: 10000

--- a/roles/filetree_create/tasks/controller_applications.yml
+++ b/roles/filetree_create/tasks/controller_applications.yml
@@ -43,16 +43,16 @@
         line: ''
         state: absent
 
-- name: "Block for to generate the filetre_create normal output"
+- name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/controller_applications output directory for applications in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_applications }} output directory for applications in {{ output_path }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
-        __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/controller_applications"
+        __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_controller_applications }}"
       loop: "{{ (applications_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | flatten | unique)
                 + ([organization] if ((applications_lookvar | map(attribute='summary_fields')
@@ -62,7 +62,7 @@
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current applications to the <ORGANIZATION_NAME>/controller_applications output file in {{ output_path }}"
+    - name: "Add current applications to the <ORGANIZATION_NAME>/{{ filetree_create_controller_applications }} output file in {{ output_path }}"
       ansible.builtin.template:
         src: "templates/controller_applications.j2"
         dest: "{{ __dest }}"
@@ -71,7 +71,7 @@
         application_organization: "{{ current_applications_asset_value.summary_fields.organization.name | default(organization, true) }}"
         application_id: "{{ current_applications_asset_value.id }}"
         application_name: "{{ current_applications_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ application_organization | regex_replace('/', '_') }}/controller_applications/{{ (application_id ~ '_') if omit_id is not defined else '' }}{{ application_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ application_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_applications }}/{{ (application_id ~ '_') if omit_id is not defined else '' }}{{ application_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ applications_lookvar }}"
       loop_control:
         loop_var: current_applications_asset_value

--- a/roles/filetree_create/tasks/controller_applications.yml
+++ b/roles/filetree_create/tasks/controller_applications.yml
@@ -46,12 +46,13 @@
 - name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_applications }} output directory for applications in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
+        __task_name_append: "{{ filetree_create_controller_applications }} output directory for applications in {{ output_path }}"
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_controller_applications }}"
       loop: "{{ (applications_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | flatten | unique)
@@ -62,12 +63,13 @@
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current applications to the <ORGANIZATION_NAME>/{{ filetree_create_controller_applications }} output file in {{ output_path }}"
+    - name: "Add current applications to the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.template:
         src: "templates/controller_applications.j2"
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
+        __task_name_append: "{{ filetree_create_controller_applications }} output file in {{ output_path }}"
         application_organization: "{{ current_applications_asset_value.summary_fields.organization.name | default(organization, true) }}"
         application_id: "{{ current_applications_asset_value.id }}"
         application_name: "{{ current_applications_asset_value.name | regex_replace('/', '_') }}"

--- a/roles/filetree_create/tasks/controller_constructed_inventories.yml
+++ b/roles/filetree_create/tasks/controller_constructed_inventories.yml
@@ -58,12 +58,13 @@
 - name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_inventories }} output directory for inventories in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
+        __task_name_append: "{{ filetree_create_controller_inventories }} output directory for inventories in {{ output_path }}"
         inventory_organization: "{{ needed_path.summary_fields.organization.name | default(organization) }}"
         inventory_name: "{{ needed_path.name | regex_replace('/', '_') }}"
         __path: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_inventories }}/{{ inventory_name | regex_replace('/', '_') }}"
@@ -72,12 +73,13 @@
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current constructed_inventories to the <ORGANIZATION_NAME>/{{ filetree_create_controller_inventories }} output yaml file in {{ output_path }}"
+    - name: "Add current constructed_inventories to the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.template:
         src: "templates/controller_inventories.j2"
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
+        __task_name_append: "{{ filetree_create_controller_inventories }} output yaml file in {{ output_path }}"
         inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default(organization) }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
         __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_inventories }}/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if omit_id is not defined else '' }}{{ inventory_name | regex_replace('/', '_') }}.yaml"

--- a/roles/filetree_create/tasks/controller_constructed_inventories.yml
+++ b/roles/filetree_create/tasks/controller_constructed_inventories.yml
@@ -58,7 +58,7 @@
 - name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/controller_inventories output directory for inventories in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_inventories }} output directory for inventories in {{ output_path }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
@@ -66,13 +66,13 @@
       vars:
         inventory_organization: "{{ needed_path.summary_fields.organization.name | default(organization) }}"
         inventory_name: "{{ needed_path.name | regex_replace('/', '_') }}"
-        __path: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/controller_inventories/{{ inventory_name | regex_replace('/', '_') }}"
+        __path: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_inventories }}/{{ inventory_name | regex_replace('/', '_') }}"
       loop: "{{ constructed_inventory_lookvar }}"
       loop_control:
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current constructed_inventories to the <ORGANIZATION_NAME>/controller_inventories output yaml file in {{ output_path }}"
+    - name: "Add current constructed_inventories to the <ORGANIZATION_NAME>/{{ filetree_create_controller_inventories }} output yaml file in {{ output_path }}"
       ansible.builtin.template:
         src: "templates/controller_inventories.j2"
         dest: "{{ __dest }}"
@@ -80,7 +80,7 @@
       vars:
         inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default(organization) }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/controller_inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if omit_id is not defined else '' }}{{ inventory_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_inventories }}/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if omit_id is not defined else '' }}{{ inventory_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ constructed_inventory_lookvar }}"
       loop_control:
         loop_var: current_inventories_asset_value
@@ -92,7 +92,7 @@
   vars:
     inventory_organization: "{{ current_inventory_sources.summary_fields.organization.name | default(organization) }}"
     inventory_name: "{{ current_inventory_sources.name | regex_replace('/', '_') }}"
-    inventory_sources_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/controller_inventories/' + inventory_name | regex_replace('/', '_'))
+    inventory_sources_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/{{ filetree_create_controller_inventories }}/' + inventory_name | regex_replace('/', '_'))
                                       if (flatten_output is not defined or (flatten_output | bool) == false)
                                       else
                                         output_path + '/inventory_sources.yaml' }}"

--- a/roles/filetree_create/tasks/controller_credential_input_sources.yml
+++ b/roles/filetree_create/tasks/controller_credential_input_sources.yml
@@ -47,14 +47,14 @@
   block:
     - name: "Create the output directory for controller_credential_input_sources: {{ output_path }}"
       ansible.builtin.file:
-        path: "{{ normal_path }}/controller_credential_input_sources"
+        path: "{{ normal_path }}/{{ filetree_create_controller_credential_input_sources }}"
         state: directory
         mode: '0755'
 
     - name: "Add current credential input sources to the output yaml file"
       ansible.builtin.template:
         src: "templates/controller_credential_input_sources.j2"
-        dest: "{{ normal_path }}/controller_credential_input_sources/controller_credential_input_sources_{{ current_credential['name'] | regex_replace('/', '_') }}.yaml"
+        dest: "{{ normal_path }}/{{ filetree_create_controller_credential_input_sources }}/{{ current_credential['name'] | regex_replace('/', '_') }}.yaml"
         mode: '0644'
       when: credential_input_sources_lookvar | length > 0
 ...

--- a/roles/filetree_create/tasks/controller_credentials.yml
+++ b/roles/filetree_create/tasks/controller_credentials.yml
@@ -43,16 +43,16 @@
         line: ''
         state: absent
 
-- name: "Block for to generate the filetre_create normal output"
+- name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/controller_credentials output directory for credentials in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_credentials }} output directory for credentials in {{ output_path }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
-        __path: "{{ output_path }}/{{ needed_path }}/controller_credentials"
+        __path: "{{ output_path }}/{{ needed_path }}/{{ filetree_create_controller_credentials }}"
       loop: "{{ (credentials_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | flatten | unique)
                 + ([organization] if ((credentials_lookvar |
@@ -62,7 +62,7 @@
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current credentials to the <ORGANIZATION_NAME>/controller_credentials output yaml file in {{ output_path }}"
+    - name: "Add current credentials to the <ORGANIZATION_NAME>/{{ filetree_create_controller_credentials }} output yaml file in {{ output_path }}"
       ansible.builtin.template:
         src: "templates/controller_credentials.j2"
         dest: "{{ __dest }}"
@@ -71,7 +71,7 @@
         credentials_organization: "{{ current_credentials_asset_value.summary_fields.organization.name | default(organization) }}"
         credentials_id: "{{ current_credentials_asset_value.id }}"
         credentials_name: "{{ current_credentials_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ credentials_organization | regex_replace('/', '_') }}/controller_credentials/{{ (credentials_id ~ '_') if omit_id is not defined else '' }}{{ credentials_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ credentials_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_credentials }}/{{ (credentials_id ~ '_') if omit_id is not defined else '' }}{{ credentials_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ credentials_lookvar }}"
       loop_control:
         loop_var: current_credentials_asset_value

--- a/roles/filetree_create/tasks/controller_credentials.yml
+++ b/roles/filetree_create/tasks/controller_credentials.yml
@@ -46,12 +46,13 @@
 - name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_credentials }} output directory for credentials in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
+        __task_name_append: "{{ filetree_create_controller_credentials }} output directory for credentials in {{ output_path }}"
         __path: "{{ output_path }}/{{ needed_path }}/{{ filetree_create_controller_credentials }}"
       loop: "{{ (credentials_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | flatten | unique)
@@ -62,12 +63,13 @@
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current credentials to the <ORGANIZATION_NAME>/{{ filetree_create_controller_credentials }} output yaml file in {{ output_path }}"
+    - name: "Add current credentials to the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.template:
         src: "templates/controller_credentials.j2"
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
+        __task_name_append: "{{ filetree_create_controller_credentials }} output yaml file in {{ output_path }}"
         credentials_organization: "{{ current_credentials_asset_value.summary_fields.organization.name | default(organization) }}"
         credentials_id: "{{ current_credentials_asset_value.id }}"
         credentials_name: "{{ current_credentials_asset_value.name | regex_replace('/', '_') }}"

--- a/roles/filetree_create/tasks/controller_groups.yml
+++ b/roles/filetree_create/tasks/controller_groups.yml
@@ -36,7 +36,7 @@
         line: ''
         state: absent
 
-- name: "Block for to generate the filetre_create normal output"
+- name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
     - name: "Create the output directory for groups: {{ groups_output_path }}"

--- a/roles/filetree_create/tasks/controller_hosts.yml
+++ b/roles/filetree_create/tasks/controller_hosts.yml
@@ -36,7 +36,7 @@
         line: ''
         state: absent
 
-- name: "Block for to generate the filetre_create normal output"
+- name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
     - name: "Create the output directory for hosts: {{ hosts_output_path }}"

--- a/roles/filetree_create/tasks/controller_inventories.yml
+++ b/roles/filetree_create/tasks/controller_inventories.yml
@@ -60,12 +60,13 @@
 - name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_inventories }} output directory for inventories in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
+        __task_name_append: "{{ filetree_create_controller_inventories }} output directory for inventories in {{ output_path }}"
         inventory_organization: "{{ needed_path.summary_fields.organization.name | default(organization) }}"
         inventory_name: "{{ needed_path.name | regex_replace('/', '_') }}"
         __path: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_inventories }}/{{ inventory_name | regex_replace('/', '_') }}"
@@ -74,12 +75,13 @@
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current inventories to the <ORGANIZATION_NAME>/{{ filetree_create_controller_inventories }} output yaml file in {{ output_path }}"
+    - name: "Add current inventories to the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.template:
         src: "templates/controller_inventories.j2"
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
+        __task_name_append: "{{ filetree_create_controller_inventories }} output yaml file in {{ output_path }}"
         inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default(organization) }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
         __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_inventories }}/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if omit_id is not defined else '' }}{{ inventory_name | regex_replace('/', '_') }}.yaml"
@@ -94,7 +96,7 @@
   vars:
     inventory_organization: "{{ current_inventory_sources.summary_fields.organization.name | default(organization) }}"
     inventory_name: "{{ current_inventory_sources.name | regex_replace('/', '_') }}"
-    inventory_sources_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/' + filetree_create_controller_inventory_sources  + '/' + inventory_name | regex_replace('/', '_'))
+    inventory_sources_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/' + filetree_create_controller_inventory_sources + '/' + inventory_name | regex_replace('/', '_'))
                                       if (flatten_output is not defined or (flatten_output | bool) == false)
                                       else
                                         output_path + '/inventory_sources.yaml' }}"

--- a/roles/filetree_create/tasks/controller_inventories.yml
+++ b/roles/filetree_create/tasks/controller_inventories.yml
@@ -57,10 +57,10 @@
         line: ''
         state: absent
 
-- name: "Block for to generate the filetre_create normal output"
+- name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/controller_inventories output directory for inventories in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_inventories }} output directory for inventories in {{ output_path }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
@@ -68,13 +68,13 @@
       vars:
         inventory_organization: "{{ needed_path.summary_fields.organization.name | default(organization) }}"
         inventory_name: "{{ needed_path.name | regex_replace('/', '_') }}"
-        __path: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/controller_inventories/{{ inventory_name | regex_replace('/', '_') }}"
+        __path: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_inventories }}/{{ inventory_name | regex_replace('/', '_') }}"
       loop: "{{ inventory_lookvar }}"
       loop_control:
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current inventories to the <ORGANIZATION_NAME>/controller_inventories output yaml file in {{ output_path }}"
+    - name: "Add current inventories to the <ORGANIZATION_NAME>/{{ filetree_create_controller_inventories }} output yaml file in {{ output_path }}"
       ansible.builtin.template:
         src: "templates/controller_inventories.j2"
         dest: "{{ __dest }}"
@@ -82,7 +82,7 @@
       vars:
         inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default(organization) }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/controller_inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if omit_id is not defined else '' }}{{ inventory_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_inventories }}/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if omit_id is not defined else '' }}{{ inventory_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ inventory_lookvar }}"
       loop_control:
         loop_var: current_inventories_asset_value
@@ -94,7 +94,7 @@
   vars:
     inventory_organization: "{{ current_inventory_sources.summary_fields.organization.name | default(organization) }}"
     inventory_name: "{{ current_inventory_sources.name | regex_replace('/', '_') }}"
-    inventory_sources_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/controller_inventories/' + inventory_name | regex_replace('/', '_'))
+    inventory_sources_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/' + filetree_create_controller_inventory_sources  + '/' + inventory_name | regex_replace('/', '_'))
                                       if (flatten_output is not defined or (flatten_output | bool) == false)
                                       else
                                         output_path + '/inventory_sources.yaml' }}"
@@ -117,7 +117,7 @@
   vars:
     inventory_organization: "{{ current_inventory_hosts.summary_fields.organization.name | default(organization) }}"
     inventory_name: "{{ current_inventory_hosts.name | regex_replace('/', '_') }}"
-    hosts_output_path: "{{ (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/controller_inventories/' + inventory_name | regex_replace('/', '_'))
+    hosts_output_path: "{{ (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/' + filetree_create_controller_hosts + '/' + inventory_name | regex_replace('/', '_'))
                           if (flatten_output is not defined or (flatten_output | bool) == false)
                           else
                             output_path + '/controller_hosts.yaml' }}"
@@ -140,7 +140,7 @@
   vars:
     inventory_organization: "{{ current_inventory_groups.summary_fields.organization.name | default(organization) }}"
     inventory_name: "{{ current_inventory_groups.name | regex_replace('/', '_') }}"
-    groups_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/controller_inventories/' + inventory_name | regex_replace('/', '_'))
+    groups_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/' + filetree_create_controller_groups + '/' + inventory_name | regex_replace('/', '_'))
                           if (flatten_output is not defined or (flatten_output | bool) == false)
                           else
                             output_path + '/groups.yaml' }}"

--- a/roles/filetree_create/tasks/controller_inventories.yml
+++ b/roles/filetree_create/tasks/controller_inventories.yml
@@ -96,7 +96,7 @@
   vars:
     inventory_organization: "{{ current_inventory_sources.summary_fields.organization.name | default(organization) }}"
     inventory_name: "{{ current_inventory_sources.name | regex_replace('/', '_') }}"
-    inventory_sources_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/' + filetree_create_controller_inventory_sources + '/' + inventory_name | regex_replace('/', '_'))
+    inventory_sources_output_path: "{{ (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/' + filetree_create_controller_inventory_sources + '/' + inventory_name | regex_replace('/', '_'))
                                       if (flatten_output is not defined or (flatten_output | bool) == false)
                                       else
                                         output_path + '/inventory_sources.yaml' }}"

--- a/roles/filetree_create/tasks/controller_inventory_sources.yml
+++ b/roles/filetree_create/tasks/controller_inventory_sources.yml
@@ -36,7 +36,7 @@
         line: ''
         state: absent
 
-- name: "Block for to generate the filetre_create normal output"
+- name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
     - name: "Create the output directory for inventory sources: {{ inventory_sources_output_path }}"

--- a/roles/filetree_create/tasks/controller_job_templates.yml
+++ b/roles/filetree_create/tasks/controller_job_templates.yml
@@ -78,16 +78,16 @@
         line: ''
         state: absent
 
-- name: "Block for to generate the filetre_create normal output"
+- name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/controller_job_templates output directories for job templates in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_templates }} output directories for job templates in {{ output_path }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
-        __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/controller_job_templates"
+        __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_controller_templates }}"
       loop: "{{ (job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
                 ([organization] if ((job_templates_lookvar | map(attribute='summary_fields') |
@@ -97,7 +97,7 @@
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current job_templates to the <ORGANIZATION_NAME>/controller_job_templates output file in {{ output_path }}"
+    - name: "Add current job_templates to the <ORGANIZATION_NAME>/{{ filetree_create_controller_templates }} output file in {{ output_path }}"
       ansible.builtin.template:
         src: "templates/controller_job_templates.j2"
         dest: "{{ __dest }}"
@@ -106,7 +106,7 @@
         job_template_organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | default(organization) }}"
         job_template_id: "{{ current_job_templates_asset_value.id }}"
         job_template_name: "{{ current_job_templates_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ job_template_organization | regex_replace('/', '_') }}/controller_job_templates/{{ (job_template_id ~ '_') if omit_id is not defined else '' }}{{ job_template_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ job_template_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_templates }}/{{ (job_template_id ~ '_') if omit_id is not defined else '' }}{{ job_template_name | regex_replace('/', '_') }}.yaml"
         query_labels: "{{ query('ansible.platform.gateway_api', current_job_templates_asset_value.related.labels,
                          host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs,
                          return_all=true, max_objects=query_controller_api_max_objects) }}"

--- a/roles/filetree_create/tasks/controller_job_templates.yml
+++ b/roles/filetree_create/tasks/controller_job_templates.yml
@@ -81,12 +81,13 @@
 - name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_templates }} output directories for job templates in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
+        __task_name_append: "{{ filetree_create_controller_templates }} output directories for job templates in {{ output_path }}"
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_controller_templates }}"
       loop: "{{ (job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
@@ -97,12 +98,13 @@
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current job_templates to the <ORGANIZATION_NAME>/{{ filetree_create_controller_templates }} output file in {{ output_path }}"
+    - name: "Add current job_templates to the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.template:
         src: "templates/controller_job_templates.j2"
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
+        __task_name_append: "{{ filetree_create_controller_templates }} output file in {{ output_path }}"
         job_template_organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | default(organization) }}"
         job_template_id: "{{ current_job_templates_asset_value.id }}"
         job_template_name: "{{ current_job_templates_asset_value.name | regex_replace('/', '_') }}"

--- a/roles/filetree_create/tasks/controller_labels.yml
+++ b/roles/filetree_create/tasks/controller_labels.yml
@@ -43,16 +43,16 @@
         line: ''
         state: absent
 
-- name: "Block for to generate the filetre_create normal output"
+- name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/controller_labels output directory for labels in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_labels }} output directory for labels in {{ output_path }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
-        __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/controller_labels"
+        __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_controller_labels }}"
       loop: "{{ (labels_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
                 + ([organization] if ((labels_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
              }}"
@@ -60,7 +60,7 @@
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current labels to the <ORGANIZATION_NAME>/controller_labels output file in {{ output_path }}"
+    - name: "Add current labels to the <ORGANIZATION_NAME>/{{ filetree_create_controller_labels }} output file in {{ output_path }}"
       ansible.builtin.template:
         src: "templates/controller_labels.j2"
         dest: "{{ __dest }}"
@@ -69,7 +69,7 @@
         label_organization: "{{ current_labels_asset_value.summary_fields.organization.name | default(organization, true) }}"
         label_id: "{{ current_labels_asset_value.id }}"
         label_name: "{{ current_labels_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ label_organization | regex_replace('/', '_') }}/controller_labels/{{ (label_id ~ '_') if omit_id is not defined else '' }}{{ label_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ label_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_labels }}/{{ (label_id ~ '_') if omit_id is not defined else '' }}{{ label_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ labels_lookvar }}"
       loop_control:
         loop_var: current_labels_asset_value

--- a/roles/filetree_create/tasks/controller_labels.yml
+++ b/roles/filetree_create/tasks/controller_labels.yml
@@ -46,12 +46,13 @@
 - name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_labels }} output directory for labels in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
+        __task_name_append: "{{ filetree_create_controller_labels }} output directory for labels in {{ output_path }}"
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_controller_labels }}"
       loop: "{{ (labels_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
                 + ([organization] if ((labels_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
@@ -60,12 +61,13 @@
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current labels to the <ORGANIZATION_NAME>/{{ filetree_create_controller_labels }} output file in {{ output_path }}"
+    - name: "Add current labels to the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.template:
         src: "templates/controller_labels.j2"
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
+        __task_name_append: "{{ filetree_create_controller_labels }} output file in {{ output_path }}"
         label_organization: "{{ current_labels_asset_value.summary_fields.organization.name | default(organization, true) }}"
         label_id: "{{ current_labels_asset_value.id }}"
         label_name: "{{ current_labels_asset_value.name | regex_replace('/', '_') }}"

--- a/roles/filetree_create/tasks/controller_notification_templates.yml
+++ b/roles/filetree_create/tasks/controller_notification_templates.yml
@@ -43,12 +43,13 @@
 - name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_notifications }} output directory for notification templates in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
+        __task_name_append: "{{ filetree_create_controller_notifications }} output directory for notification templates in {{ output_path }}"
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_controller_notifications }}"
       loop: "{{ (notification_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | flatten | unique) +

--- a/roles/filetree_create/tasks/controller_notification_templates.yml
+++ b/roles/filetree_create/tasks/controller_notification_templates.yml
@@ -40,16 +40,16 @@
         line: ''
         state: absent
 
-- name: "Block for to generate the filetre_create normal output"
+- name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/controller_notification_templates output directory for notification templates in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_notifications }} output directory for notification templates in {{ output_path }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
-        __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/controller_notification_templates"
+        __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_controller_notifications }}"
       loop: "{{ (notification_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
                 ([organization] if ((notification_templates_lookvar | map(attribute='summary_fields') |
@@ -65,7 +65,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        __dest: "{{ output_path }}/{{ (current_notification_templates_asset_value.summary_fields.organization.name | default(organization, true)) | regex_replace('/', '_') }}/controller_notification_templates/{{ current_notification_templates_asset_value.name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ (current_notification_templates_asset_value.summary_fields.organization.name | default(organization, true)) | regex_replace('/', '_') }}/{{ filetree_create_controller_notifications }}/{{ current_notification_templates_asset_value.name | regex_replace('/', '_') }}.yaml"
       loop: "{{ notification_templates_lookvar }}"
       loop_control:
         loop_var: current_notification_templates_asset_value

--- a/roles/filetree_create/tasks/controller_organizations.yml
+++ b/roles/filetree_create/tasks/controller_organizations.yml
@@ -53,7 +53,7 @@
         line: ''
         state: absent
 
-- name: "Block for to generate the filetre_create normal output"
+- name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
     - name: "Create the output directory for organizations: {{ output_path + '/' + current_organization_dir.name }}"

--- a/roles/filetree_create/tasks/controller_projects.yml
+++ b/roles/filetree_create/tasks/controller_projects.yml
@@ -57,12 +57,13 @@
 - name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_projects }} output directory for projects in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
+        __task_name_append: "{{ filetree_create_controller_projects }} output directory for projects in {{ output_path }}"
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_controller_projects }}"
       loop: "{{ (projects_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
@@ -73,12 +74,13 @@
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current projects to the <ORGANIZATION_NAME>/{{ filetree_create_controller_projects }} output file in {{ output_path }}"
+    - name: "Add current projects to the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.template:
         src: "templates/controller_projects.j2"
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
+        __task_name_append: "{{ filetree_create_controller_projects }} output file in {{ output_path }}"
         project_organization: "{{ current_projects_asset_value.summary_fields.organization.name | default(organization, true) }}"
         project_id: "{{ current_projects_asset_value.id }}"
         project_name: "{{ current_projects_asset_value.name | regex_replace('/', '_') }}"

--- a/roles/filetree_create/tasks/controller_projects.yml
+++ b/roles/filetree_create/tasks/controller_projects.yml
@@ -54,16 +54,16 @@
         line: ''
         state: absent
 
-- name: "Block for to generate the filetre_create normal output"
+- name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/controller_projects output directory for projects in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_projects }} output directory for projects in {{ output_path }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
-        __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/controller_projects"
+        __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_controller_projects }}"
       loop: "{{ (projects_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
                 ([organization] if ((projects_lookvar | map(attribute='summary_fields') |
@@ -73,7 +73,7 @@
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current projects to the <ORGANIZATION_NAME>/controller_projects output file in {{ output_path }}"
+    - name: "Add current projects to the <ORGANIZATION_NAME>/{{ filetree_create_controller_projects }} output file in {{ output_path }}"
       ansible.builtin.template:
         src: "templates/controller_projects.j2"
         dest: "{{ __dest }}"
@@ -82,7 +82,7 @@
         project_organization: "{{ current_projects_asset_value.summary_fields.organization.name | default(organization, true) }}"
         project_id: "{{ current_projects_asset_value.id }}"
         project_name: "{{ current_projects_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ project_organization | regex_replace('/', '_') }}/controller_projects/{{ (project_id ~ '_') if omit_id is not defined else '' }}{{ project_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ project_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_projects }}/{{ (project_id ~ '_') if omit_id is not defined else '' }}{{ project_name | regex_replace('/', '_') }}.yaml"
         query_notification_error: "{{ query('ansible.platform.gateway_api', current_projects_asset_value.related.notification_templates_error,
                          host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs,
                          return_all=true, max_objects=query_controller_api_max_objects) }}"

--- a/roles/filetree_create/tasks/controller_schedules.yml
+++ b/roles/filetree_create/tasks/controller_schedules.yml
@@ -48,12 +48,12 @@
         line: ''
         state: absent
 
-- name: "Block for to generate the filetre_create normal output"
+- name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
     - name: "Create the controller_schedules output directory for schedules in {{ output_path }}"
       ansible.builtin.file:
-        path: "{{ output_path }}/controller_schedules"
+        path: "{{ output_path }}/{{ filetree_create_controller_schedules }}"
         state: directory
         mode: '0755'
 
@@ -65,7 +65,7 @@
       vars:
         label_id: "{{ current_schedules_asset_value.id }}"
         label_name: "{{ current_schedules_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/controller_schedules/{{ (label_id ~ '_') if omit_id is not defined else '' }}{{ label_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ filetree_create_controller_schedules }}/{{ (label_id ~ '_') if omit_id is not defined else '' }}{{ label_name | regex_replace('/', '_') }}.yaml"
         query_credentials: "{{ query('ansible.platform.gateway_api', current_schedules_asset_value.related.credentials,
                      host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs,
                      return_all=true, max_objects=query_controller_api_max_objects) if current_schedules_asset_value.related.credentials is defined else [] }}"

--- a/roles/filetree_create/tasks/controller_team_roles.yml
+++ b/roles/filetree_create/tasks/controller_team_roles.yml
@@ -63,20 +63,20 @@
         line: ''
         state: absent
 
-- name: "Block for to generate the filetre_create normal output"
+- name: "Block for to generate the filetree_create normal output"
   when:
     - flatten_output is not defined or not (flatten_output | bool)
   block:
     - name: "Create the output directory for controller_team roles: {{ output_path }}"
       ansible.builtin.file:
-        path: "{{ output_path }}/controller_team_roles"
+        path: "{{ output_path }}/{{ filetree_create_controller_team_roles }}"
         state: directory
         mode: '0755'
 
     - name: "Add current roles to the output yaml file"
       ansible.builtin.template:
         src: "templates/controller_team_roles.j2"
-        dest: "{{ output_path }}/controller_team_roles/controller_roles_{{ team_name | regex_replace('/', '_') }}.yaml"
+        dest: "{{ output_path }}/{{ filetree_create_controller_team_roles }}/{{ team_name | regex_replace('/', '_') }}.yaml"
         mode: '0644'
       when: object_roles | length > 0
 ...

--- a/roles/filetree_create/tasks/controller_teams.yml
+++ b/roles/filetree_create/tasks/controller_teams.yml
@@ -46,12 +46,13 @@
 - name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_teams }} output directory for teams in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
+        __task_name_append: "{{ filetree_create_controller_teams }} output directory for teams in {{ output_path }}"
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_controller_teams }}"
       loop: "{{ (teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | unique) +
@@ -62,12 +63,13 @@
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current teams to the <ORGANIZATION_NAME>/{{ filetree_create_controller_teams }} output file in {{ output_path }}"
+    - name: "Add current teams to the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.template:
         src: "templates/controller_teams.j2"
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
+        __task_name_append: "{{ filetree_create_controller_teams }} output file in {{ output_path }}"
         team_organization: "{{ (current_teams_asset_value.summary_fields.organization.name | default(organization, true)) | regex_replace('/', '_') }}"
         team_id: "{{ current_teams_asset_value.id }}"
         team_name: "{{ current_teams_asset_value.name | regex_replace('/', '_') }}"

--- a/roles/filetree_create/tasks/controller_teams.yml
+++ b/roles/filetree_create/tasks/controller_teams.yml
@@ -43,16 +43,16 @@
         line: ''
         state: absent
 
-- name: "Block for to generate the filetre_create normal output"
+- name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/controller_teams output directory for teams in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_teams }} output directory for teams in {{ output_path }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
-        __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/controller_teams"
+        __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_controller_teams }}"
       loop: "{{ (teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | unique) +
                 ([organization] if ((teams_lookvar | map(attribute='summary_fields') |
@@ -62,7 +62,7 @@
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current teams to the <ORGANIZATION_NAME>/controller_teams output file in {{ output_path }}"
+    - name: "Add current teams to the <ORGANIZATION_NAME>/{{ filetree_create_controller_teams }} output file in {{ output_path }}"
       ansible.builtin.template:
         src: "templates/controller_teams.j2"
         dest: "{{ __dest }}"
@@ -71,7 +71,7 @@
         team_organization: "{{ (current_teams_asset_value.summary_fields.organization.name | default(organization, true)) | regex_replace('/', '_') }}"
         team_id: "{{ current_teams_asset_value.id }}"
         team_name: "{{ current_teams_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ team_organization | regex_replace('/', '_') }}/controller_teams/{{ (team_id ~ '_') if omit_id is not defined else '' }}{{ team_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ team_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_teams }}/{{ (team_id ~ '_') if omit_id is not defined else '' }}{{ team_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ teams_lookvar }}"
       loop_control:
         loop_var: current_teams_asset_value

--- a/roles/filetree_create/tasks/controller_user_roles.yml
+++ b/roles/filetree_create/tasks/controller_user_roles.yml
@@ -65,21 +65,21 @@
         line: ''
         state: absent
 
-- name: "Block for to generate the filetre_create normal output"
+- name: "Block for to generate the filetree_create normal output"
   when:
     - flatten_output is not defined or not (flatten_output | bool)
     - user_roles_lookvar | length > 0
   block:
     - name: "Create the output directory for controller_user roles: {{ output_path }}"
       ansible.builtin.file:
-        path: "{{ output_path }}/controller_user_roles"
+        path: "{{ output_path }}/{{ filetree_create_controller_user_roles }}"
         state: directory
         mode: '0755'
 
     - name: "Add current roles to the output yaml file"
       ansible.builtin.template:
         src: "templates/controller_user_roles.j2"
-        dest: "{{ output_path }}/controller_user_roles/controller_user_roles_{{ username | regex_replace('/', '_') }}.yaml"
+        dest: "{{ output_path }}/{{ filetree_create_controller_user_roles }}/{{ username | regex_replace('/', '_') }}.yaml"
         mode: '0644'
       when: object_roles | length > 0
 ...

--- a/roles/filetree_create/tasks/controller_users.yml
+++ b/roles/filetree_create/tasks/controller_users.yml
@@ -57,7 +57,7 @@
         line: ''
         state: absent
 
-- name: "Block for to generate the filetre_create normal output"
+- name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
     - name: "Create the <ORGANIZATION_NAME> output directory for users in {{ output_path }}"
@@ -66,21 +66,21 @@
         state: directory
         mode: '0755'
       vars:
-        __path: "{{ output_path }}/{{ current_user_dir | regex_replace('/', '_') }}/controller_users"
+        __path: "{{ output_path }}/{{ current_user_dir | regex_replace('/', '_') }}/{{ filetree_create_controller_user_accounts }}"
       when: organization_filter is not defined or (current_user_dir is match(organization_filter))
       loop: "{{ current_users | selectattr('organizations', 'defined') | map(attribute='organizations') | flatten | unique }}"
       loop_control:
         loop_var: current_user_dir
         label: "{{ __path }}"
 
-    - name: "Add current users to the <ORGANIZATION_NAME>/controller_<USERNAME>.yaml output file in {{ output_path }}"
+    - name: "Add current users to the <ORGANIZATION_NAME>/<USERNAME>.yaml output file in {{ output_path }}"
       ansible.builtin.template:
         src: "templates/controller_users.j2"
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
         current_users_asset_value: "{{ current_user_dir.0 }}"
-        __dest: "{{ output_path }}/{{ current_user_dir.1 | regex_replace('/', '_') }}/controller_users/controller_{{ current_user_dir.0.username | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ current_user_dir.1 | regex_replace('/', '_') }}/{{ filetree_create_controller_user_accounts }}/{{ current_user_dir.0.username | regex_replace('/', '_') }}.yaml"
       when: organization_filter is not defined or (current_user_dir.1 is match(organization_filter))
       loop: "{{ current_users | default([]) | subelements('organizations', skip_missing=true) }}"
       loop_control:

--- a/roles/filetree_create/tasks/controller_workflow_job_templates.yml
+++ b/roles/filetree_create/tasks/controller_workflow_job_templates.yml
@@ -81,16 +81,16 @@
         line: ''
         state: absent
 
-- name: "Block for to generate the filetre_create normal output"
+- name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/controller_workflow_job_templates output directory for workflow job templates in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_workflow_job_templates }} output directory for workflow job templates in {{ output_path }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
-        __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/controller_workflow_job_templates/"
+        __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_controller_workflow_job_templates }}/"
       loop: "{{ (workflow_job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
                 ([organization] if ((workflow_job_templates_lookvar | map(attribute='summary_fields') |
@@ -100,7 +100,7 @@
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current workflow job templates to the <ORGANIZATION_NAME>/controller_workflow_job_templates output file in {{ output_path }}"
+    - name: "Add current workflow job templates to the <ORGANIZATION_NAME>/{{ filetree_create_controller_workflow_job_templates }} output file in {{ output_path }}"
       ansible.builtin.template:
         src: "templates/controller_workflow_job_templates.j2"
         dest: "{{ __dest }}"
@@ -109,7 +109,7 @@
         workflow_job_template_organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default(organization) }}"
         workflow_job_template_id: "{{ current_workflow_job_templates_asset_value.id }}"
         workflow_job_template_name: "{{ current_workflow_job_templates_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ workflow_job_template_organization | regex_replace('/', '_') }}/controller_workflow_job_templates/{{ (workflow_job_template_id ~ '_') if omit_id is not defined else '' }}{{ workflow_job_template_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ workflow_job_template_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_workflow_job_templates }}/{{ (workflow_job_template_id ~ '_') if omit_id is not defined else '' }}{{ workflow_job_template_name | regex_replace('/', '_') }}.yaml"
         query_labels: "{{ query('ansible.platform.gateway_api', current_workflow_job_templates_asset_value.related.labels,
                          host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs,
                          return_all=true, max_objects=query_controller_api_max_objects) }}"

--- a/roles/filetree_create/tasks/controller_workflow_job_templates.yml
+++ b/roles/filetree_create/tasks/controller_workflow_job_templates.yml
@@ -84,12 +84,13 @@
 - name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_controller_workflow_job_templates }} output directory for workflow job templates in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
+        __task_name_append: "{{ filetree_create_controller_workflow_job_templates }} output directory for workflow job templates in {{ output_path }}"
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_controller_workflow_job_templates }}/"
       loop: "{{ (workflow_job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
@@ -100,12 +101,13 @@
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current workflow job templates to the <ORGANIZATION_NAME>/{{ filetree_create_controller_workflow_job_templates }} output file in {{ output_path }}"
+    - name: "Add current workflow job templates to the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.template:
         src: "templates/controller_workflow_job_templates.j2"
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
+        __task_name_append: "{{ filetree_create_controller_workflow_job_templates }} output file in {{ output_path }}"
         workflow_job_template_organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default(organization) }}"
         workflow_job_template_id: "{{ current_workflow_job_templates_asset_value.id }}"
         workflow_job_template_name: "{{ current_workflow_job_templates_asset_value.name | regex_replace('/', '_') }}"

--- a/roles/filetree_create/tasks/eda_projects.yml
+++ b/roles/filetree_create/tasks/eda_projects.yml
@@ -58,16 +58,16 @@
             line: ''
             state: absent
 
-    - name: "Block for to generate the filetre_create normal output"
+    - name: "Block for to generate the filetree_create normal output"
       when: flatten_output is not defined or not (flatten_output | bool)
       block:
-        - name: "Create the <ORGANIZATION_NAME>/eda_projects output directory for projects in {{ output_path }}"
+        - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_eda_projects }} output directory for projects in {{ output_path }}"
           ansible.builtin.file:
             path: "{{ __path }}"
             state: directory
             mode: '0755'
           vars:
-            __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/eda_projects"
+            __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_eda_projects }}"
           loop: "{{ (projects_lookvar | selectattr('organization_id', 'defined') |
                     map(attribute='organization_id') | list | flatten | unique) +
                     ([organization] if ((projects_lookvar | selectattr('organization', 'undefined') | list) | flatten | length > 0) else [])
@@ -76,7 +76,7 @@
             loop_var: needed_path
             label: "{{ __path }}"
 
-        - name: "Add current projects to the <ORGANIZATION_NAME>/eda_projects output file in {{ output_path }}"
+        - name: "Add current projects to the <ORGANIZATION_NAME>/{{ filetree_create_eda_projects }} output file in {{ output_path }}"
           ansible.builtin.template:
             src: "templates/eda_projects.j2"
             dest: "{{ __dest }}"
@@ -85,7 +85,7 @@
             project_organization: "{{ current_projects_asset_value.organization_id | default(organization, true) }}"
             project_id: "{{ current_projects_asset_value.id }}"
             project_name: "{{ current_projects_asset_value.name | regex_replace('/', '_') }}"
-            __dest: "{{ output_path }}/{{ project_organization | regex_replace('/', '_') }}/eda_projects/{{ (project_id ~ '_') if omit_id is not defined else '' }}{{ project_name | regex_replace('/', '_') }}.yaml"
+            __dest: "{{ output_path }}/{{ project_organization | regex_replace('/', '_') }}/{{ filetree_create_eda_projects }}/{{ (project_id ~ '_') if omit_id is not defined else '' }}{{ project_name | regex_replace('/', '_') }}.yaml"
             query_notification_error: "{{ query('ansible.platform.gateway_api', current_projects_asset_value.related.notification_templates_error,
                              host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs,
                              return_all=true, max_objects=query_eda_api_max_objects) }}"

--- a/roles/filetree_create/tasks/eda_projects.yml
+++ b/roles/filetree_create/tasks/eda_projects.yml
@@ -61,12 +61,13 @@
     - name: "Block for to generate the filetree_create normal output"
       when: flatten_output is not defined or not (flatten_output | bool)
       block:
-        - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_eda_projects }} output directory for projects in {{ output_path }}"
+        - name: "Create the <ORGANIZATION_NAME>/{{ __task_name_append }}"
           ansible.builtin.file:
             path: "{{ __path }}"
             state: directory
             mode: '0755'
           vars:
+            __task_name_append: "{{ filetree_create_eda_projects }} output directory for projects in {{ output_path }}"
             __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_eda_projects }}"
           loop: "{{ (projects_lookvar | selectattr('organization_id', 'defined') |
                     map(attribute='organization_id') | list | flatten | unique) +
@@ -76,12 +77,13 @@
             loop_var: needed_path
             label: "{{ __path }}"
 
-        - name: "Add current projects to the <ORGANIZATION_NAME>/{{ filetree_create_eda_projects }} output file in {{ output_path }}"
+        - name: "Add current projects to the <ORGANIZATION_NAME>/{{ __task_name_append }}"
           ansible.builtin.template:
             src: "templates/eda_projects.j2"
             dest: "{{ __dest }}"
             mode: '0644'
           vars:
+            __task_name_append: "{{ filetree_create_eda_projects }} output file in {{ output_path }}"
             project_organization: "{{ current_projects_asset_value.organization_id | default(organization, true) }}"
             project_id: "{{ current_projects_asset_value.id }}"
             project_name: "{{ current_projects_asset_value.name | regex_replace('/', '_') }}"

--- a/roles/filetree_create/tasks/eda_rulebook_activations.yml
+++ b/roles/filetree_create/tasks/eda_rulebook_activations.yml
@@ -64,16 +64,16 @@
             line: ''
             state: absent
 
-    - name: "Block for to generate the filetre_create normal output"
+    - name: "Block for to generate the filetree_create normal output"
       when: flatten_output is not defined or not (flatten_output | bool)
       block:
-        - name: "Create the <ORGANIZATION_NAME>/eda_rulebook_activations output directory for rulebook_activations in {{ output_path }}"
+        - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_eda_rulebook_activations }} output directory for rulebook_activations in {{ output_path }}"
           ansible.builtin.file:
             path: "{{ __path }}"
             state: directory
             mode: '0755'
           vars:
-            __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/eda_rulebook_activations"
+            __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_eda_rulebook_activations }}"
           loop: "{{ (rulebook_activations_lookvar | selectattr('organization_id', 'defined') |
                     map(attribute='organization_id') | list | flatten | unique) +
                     ([organization] if ((rulebook_activations_lookvar | selectattr('organization', 'undefined') | list) | flatten | length > 0) else [])
@@ -82,7 +82,7 @@
             loop_var: needed_path
             label: "{{ __path }}"
 
-        - name: "Add current rulebook_activations to the <ORGANIZATION_NAME>/eda_rulebook_activations output file in {{ output_path }}"
+        - name: "Add current rulebook_activations to the <ORGANIZATION_NAME>/{{ filetree_create_eda_rulebook_activations }} output file in {{ output_path }}"
           ansible.builtin.template:
             src: "templates/eda_rulebook_activations.j2"
             dest: "{{ __dest }}"
@@ -91,7 +91,7 @@
             rulebook_activation_organization: "{{ current_rulebook_activations_asset_value.organization_id | default(organization, true) }}"
             rulebook_activation_id: "{{ current_rulebook_activations_asset_value.id }}"
             rulebook_activation_name: "{{ current_rulebook_activations_asset_value.name | regex_replace('/', '_') }}"
-            __dest: "{{ output_path }}/{{ rulebook_activation_organization | regex_replace('/', '_') }}/eda_rulebook_activations/{{ (rulebook_activation_id ~ '_') if omit_id is not defined else '' }}{{ rulebook_activation_name | regex_replace('/', '_') }}.yaml"
+            __dest: "{{ output_path }}/{{ rulebook_activation_organization | regex_replace('/', '_') }}/{{ filetree_create_eda_rulebook_activations }}/{{ (rulebook_activation_id ~ '_') if omit_id is not defined else '' }}{{ rulebook_activation_name | regex_replace('/', '_') }}.yaml"
             query_organization_name: "{{ (query('ansible.platform.gateway_api', 'api/eda/v1/organizations/' + current_rulebook_activations_asset_value.decision_environment_id | string,
                                                 host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs,
                                                 return_all=true, max_objects=query_eda_api_max_objects) | first).name

--- a/roles/filetree_create/tasks/eda_rulebook_activations.yml
+++ b/roles/filetree_create/tasks/eda_rulebook_activations.yml
@@ -67,12 +67,13 @@
     - name: "Block for to generate the filetree_create normal output"
       when: flatten_output is not defined or not (flatten_output | bool)
       block:
-        - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_eda_rulebook_activations }} output directory for rulebook_activations in {{ output_path }}"
+        - name: "Create the <ORGANIZATION_NAME>/{{ __task_name_append }}"
           ansible.builtin.file:
             path: "{{ __path }}"
             state: directory
             mode: '0755'
           vars:
+            __task_name_append: "{{ filetree_create_eda_rulebook_activations }} output directory for rulebook_activations in {{ output_path }}"
             __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_eda_rulebook_activations }}"
           loop: "{{ (rulebook_activations_lookvar | selectattr('organization_id', 'defined') |
                     map(attribute='organization_id') | list | flatten | unique) +
@@ -82,12 +83,13 @@
             loop_var: needed_path
             label: "{{ __path }}"
 
-        - name: "Add current rulebook_activations to the <ORGANIZATION_NAME>/{{ filetree_create_eda_rulebook_activations }} output file in {{ output_path }}"
+        - name: "Add current rulebook_activations to the <ORGANIZATION_NAME>/{{ __task_name_append }}"
           ansible.builtin.template:
             src: "templates/eda_rulebook_activations.j2"
             dest: "{{ __dest }}"
             mode: '0644'
           vars:
+            __task_name_append: "{{ filetree_create_eda_rulebook_activations }} output file in {{ output_path }}"
             rulebook_activation_organization: "{{ current_rulebook_activations_asset_value.organization_id | default(organization, true) }}"
             rulebook_activation_id: "{{ current_rulebook_activations_asset_value.id }}"
             rulebook_activation_name: "{{ current_rulebook_activations_asset_value.name | regex_replace('/', '_') }}"

--- a/roles/filetree_create/tasks/gateway_applications.yml
+++ b/roles/filetree_create/tasks/gateway_applications.yml
@@ -46,12 +46,13 @@
 - name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_aap_applications }} output directory for applications in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
+        __task_name_append: "{{ filetree_create_aap_applications }} output directory for applications in {{ output_path }}"
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_aap_applications }}"
       loop: "{{ (applications_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | flatten | unique)
@@ -62,12 +63,13 @@
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current applications to the <ORGANIZATION_NAME>/{{ filetree_create_aap_applications }} output file in {{ output_path }}"
+    - name: "Add current applications to the <ORGANIZATION_NAME>/{{ __task_name_append }}"
       ansible.builtin.template:
         src: "templates/gateway_applications.j2"
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
+        __task_name_append: "{{ filetree_create_aap_applications }} output file in {{ output_path }}"
         application_organization: "{{ current_applications_asset_value.summary_fields.organization.name | default(organization, true) }}"
         application_id: "{{ current_applications_asset_value.id }}"
         application_name: "{{ current_applications_asset_value.name | regex_replace('/', '_') }}"

--- a/roles/filetree_create/tasks/gateway_applications.yml
+++ b/roles/filetree_create/tasks/gateway_applications.yml
@@ -43,16 +43,16 @@
         line: ''
         state: absent
 
-- name: "Block for to generate the filetre_create normal output"
+- name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the <ORGANIZATION_NAME>/gateway_applications output directory for applications in {{ output_path }}"
+    - name: "Create the <ORGANIZATION_NAME>/{{ filetree_create_aap_applications }} output directory for applications in {{ output_path }}"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory
         mode: '0755'
       vars:
-        __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/gateway_applications"
+        __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/{{ filetree_create_aap_applications }}"
       loop: "{{ (applications_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | flatten | unique)
                 + ([organization] if ((applications_lookvar | map(attribute='summary_fields')
@@ -62,7 +62,7 @@
         loop_var: needed_path
         label: "{{ __path }}"
 
-    - name: "Add current applications to the <ORGANIZATION_NAME>/gateway_applications output file in {{ output_path }}"
+    - name: "Add current applications to the <ORGANIZATION_NAME>/{{ filetree_create_aap_applications }} output file in {{ output_path }}"
       ansible.builtin.template:
         src: "templates/gateway_applications.j2"
         dest: "{{ __dest }}"
@@ -71,7 +71,7 @@
         application_organization: "{{ current_applications_asset_value.summary_fields.organization.name | default(organization, true) }}"
         application_id: "{{ current_applications_asset_value.id }}"
         application_name: "{{ current_applications_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ application_organization | regex_replace('/', '_') }}/gateway_applications/{{ (application_id ~ '_') if omit_id is not defined else '' }}{{ application_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ application_organization | regex_replace('/', '_') }}/{{ filetree_create_aap_applications }}/{{ (application_id ~ '_') if omit_id is not defined else '' }}{{ application_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ applications_lookvar }}"
       loop_control:
         loop_var: current_applications_asset_value


### PR DESCRIPTION
<!--- markdownlint-disable -->
# What does this PR do?
Allows you to override the output folder names that `filetree_create` uses when creating the non-flat output.

## How should this be tested?
Test like normal

## Is there a relevant Issue open for this?
N/A

## Other Relevant info, PRs, etc
N/A
