### PR TITLE
Fix Workflow Job Templates failing to export on filetree_create when using approval nodes

### DIFF
--- a/changelogs/filetree_create_workflow_job_templates.yml
+++ b/changelogs/filetree_create_workflow_job_templates.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Ensure approval nodes are now exported using the `approval_node:` block instead of `unified_job_template:`.

--- a/roles/filetree_create/templates/controller_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/controller_workflow_job_templates.j2
@@ -18,7 +18,12 @@ controller_workflows:
         inventory: "{{ node.summary_fields.inventory.name }}"
 {% endif %}
         workflow_job_template: "{{ node.summary_fields.workflow_job_template.name }}"
-{% if node.summary_fields.unified_job_template.unified_job_type is not match('approval') %}
+{% if node.summary_fields.unified_job_template.unified_job_type is match('approval') %}
+        approval_node:
+          description: "{{ node.summary_fields.unified_job_template.description }}"
+          name: "{{ node.summary_fields.unified_job_template.name }}"
+          timeout: {{ node.summary_fields.unified_job_template.timeout }}
+{% else %}
         unified_job_template: "{{ node.summary_fields.unified_job_template.name | default('ToDo: The node is pointing to a deleted Job Template') }}"
 {%   if node.verbosity != None %}
         verbosity: "{{ node.verbosity }}"
@@ -39,12 +44,6 @@ controller_workflows:
 {% endif %}
 {% if node.job_type %}
         job_type: "{{ node.job_type }}"
-{% if node.summary_fields.unified_job_template.unified_job_type is match('approval') %}
-        approval_node:
-          description: "{{ node.summary_fields.unified_job_template.description }}"
-          name: "{{ node.summary_fields.unified_job_template.name }}"
-          timeout: {{ node.summary_fields.unified_job_template.timeout }}
-{% endif %}
 {% endif %}
         organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default(organization if organization != 'ORGANIZATIONLESS' else 'ToDo: The WF \'' + current_workflow_job_templates_asset_value.name + '\' must belong to an organization') }}"
         all_parents_must_converge: "{{ node.all_parents_must_converge }}"

--- a/roles/filetree_create/templates/controller_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/controller_workflow_job_templates.j2
@@ -18,7 +18,7 @@ controller_workflows:
         inventory: "{{ node.summary_fields.inventory.name }}"
 {% endif %}
         workflow_job_template: "{{ node.summary_fields.workflow_job_template.name }}"
-{% if node.summary_fields.unified_job_template.unified_job_type is match('approval') %}
+{% if node.summary_fields.unified_job_template.unified_job_type == 'workflow_approval' %}
         approval_node:
           description: "{{ node.summary_fields.unified_job_template.description }}"
           name: "{{ node.summary_fields.unified_job_template.name }}"


### PR DESCRIPTION
<!--- markdownlint-disable -->
# What does this PR do?
Properly exports workflow job template and approval nodes

## How should this be tested?
- name: "Export | Include filetree_create role for Workflow Job Templates"
  ansible.builtin.include_role:
    name: infra.aap_configuration_extended.filetree_create
  vars:
    output_path: "/tmp/filetree"
    input_tag:
      - controller_workflow_job_templates
    valid_tags:
      - controller_workflow_job_templates
     

## Is there a relevant Issue open for this?
https://github.com/redhat-cop/aap_configuration_extended/issues/181
