### PR TITLE
secrets_as_variables changes

### DIFF
--- a/changelogs/fragments/secrets_as_variables_changes.yml
+++ b/changelogs/fragments/secrets_as_variables_changes.yml
@@ -1,0 +1,5 @@
+---
+major_changes:
+  - Set `secrets_as_variables` to `true` in defaults/main.yml as this is safer instead of accidentally importing `''` or `'$encrypted$`
+  - Remove `| default('$encrypted$')` when `secrets_as_variables` is `true`. This will cause `dispatch` to fail with `variable undefined` instead of accidentally changing the secret.
+...

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -25,7 +25,7 @@ The following variables are required for that role to work properly:
 | `output_path` | `/tmp/filetree_output` | yes | str | The path to the output directory where all the generated `yaml` files with the corresponding Objects as code will be written to. |
 | `input_tag` | `['all']` | no | List of Strings | The tags which are applied to the 'sub-roles'. If 'all' is in the list (the default value) then all roles will be called.  Valid tags can be found under `vars/valid_tags`. |
 | `flatten_output` | N/A | no | bool | Whether to flatten the output in single files per each object type instead of the normal exportation structure. |
-| `secrets_as_variables` | N/A | no | bool | Whether to export the secrets as variables that can be populated from existing variables/files. An example: `vaulted_eda_credentials_my_eda_credential_password`, that follows the syntax: `<secrets_as_variables_prefix>_<object_type>_<object_name>_<field_name>`. |
+| `secrets_as_variables` | True | no | bool | Whether to export the secrets as variables that can be populated from existing variables/files. An example: `vaulted_eda_credentials_my_eda_credential_password`, that follows the syntax: `<secrets_as_variables_prefix>_<object_type>_<object_name>_<field_name>`. |
 | `secrets_as_variables_prefix` | vaulted | no | str | The prefix to use for the variables defined by `secrets_as_variables` feature. |
 | `show_encrypted` | N/A | no | bool | Whether to remove the string '\$encrypted\$' in credentials output (not the actual credential value). |
 | `omit_id` | N/A | no | bool | Whether to create output files without objects id. |

--- a/roles/filetree_create/defaults/main.yml
+++ b/roles/filetree_create/defaults/main.yml
@@ -63,5 +63,6 @@ input_tag:
   - all
 organization: 'ORGANIZATIONLESS'
 
+secrets_as_variables: true
 secrets_as_variables_prefix: "vaulted"
 ...

--- a/roles/filetree_create/templates/controller_credentials.j2
+++ b/roles/filetree_create/templates/controller_credentials.j2
@@ -22,7 +22,7 @@ controller_credentials:
         {{ input.value | indent(width=8) }}
 {%     elif show_encrypted is defined and show_encrypted %}
       {{ input.key }}: {{ input.value }}
-{%     elif secrets_as_variables | default(true) | bool %}
+{%     elif secrets_as_variables | bool %}
       {{ input.key }}: {{ input.value | replace("$encrypted$", "\"{{ " + secrets_as_variables_prefix + "_controller_credentials_" + (current_credentials_asset_value.name | lower | regex_replace('[^a-z0-9]','_')) + "_" + (input.key | lower | regex_replace('[^a-z0-9]', '_')) + " }}\"") }}
 {%     else %}
       {{ input.key }}: {{ input.value | replace("$encrypted$", "\'\'") }}

--- a/roles/filetree_create/templates/controller_credentials.j2
+++ b/roles/filetree_create/templates/controller_credentials.j2
@@ -23,7 +23,7 @@ controller_credentials:
 {%     elif show_encrypted is defined and show_encrypted %}
       {{ input.key }}: {{ input.value }}
 {%     elif secrets_as_variables is defined and secrets_as_variables %}
-      {{ input.key }}: {{ input.value | replace("$encrypted$", "\"{{ " + secrets_as_variables_prefix + "_controller_credentials_" + (current_credentials_asset_value.name | lower | regex_replace('[^a-z0-9]','_')) + "_" + (input.key | lower | regex_replace('[^a-z0-9]', '_')) + " | default('$encrypted$') }}\"") }}
+      {{ input.key }}: {{ input.value | replace("$encrypted$", "\"{{ " + secrets_as_variables_prefix + "_controller_credentials_" + (current_credentials_asset_value.name | lower | regex_replace('[^a-z0-9]','_')) + "_" + (input.key | lower | regex_replace('[^a-z0-9]', '_')) + " }}\"") }}
 {%     else %}
       {{ input.key }}: {{ input.value | replace("$encrypted$", "\'\'") }}
 {%     endif %}

--- a/roles/filetree_create/templates/controller_credentials.j2
+++ b/roles/filetree_create/templates/controller_credentials.j2
@@ -22,7 +22,7 @@ controller_credentials:
         {{ input.value | indent(width=8) }}
 {%     elif show_encrypted is defined and show_encrypted %}
       {{ input.key }}: {{ input.value }}
-{%     elif secrets_as_variables is defined and secrets_as_variables %}
+{%     elif secrets_as_variables | default(true) | bool %}
       {{ input.key }}: {{ input.value | replace("$encrypted$", "\"{{ " + secrets_as_variables_prefix + "_controller_credentials_" + (current_credentials_asset_value.name | lower | regex_replace('[^a-z0-9]','_')) + "_" + (input.key | lower | regex_replace('[^a-z0-9]', '_')) + " }}\"") }}
 {%     else %}
       {{ input.key }}: {{ input.value | replace("$encrypted$", "\'\'") }}

--- a/roles/filetree_create/templates/controller_users.j2
+++ b/roles/filetree_create/templates/controller_users.j2
@@ -5,7 +5,7 @@ aap_user_accounts:
 - username: "{{ current_users_asset_value.username }}"
 {%  if show_encrypted is defined and show_encrypted %}
   password: "{{ current_users_asset_value.password }}"
-{%  elif secrets_as_variables | default(true) | bool %}
+{%  elif secrets_as_variables | bool %}
   password: "{{ current_users_asset_value.password | replace("$encrypted$", "{{ " + secrets_as_variables_prefix + "controller_users_" + (current_users_asset_value.username | replace(' ', '_') | lower) + "_password }}") }}"
 {%  else %}
   password: "INITIAL"

--- a/roles/filetree_create/templates/controller_users.j2
+++ b/roles/filetree_create/templates/controller_users.j2
@@ -5,7 +5,7 @@ aap_user_accounts:
 - username: "{{ current_users_asset_value.username }}"
 {%  if show_encrypted is defined and show_encrypted %}
   password: "{{ current_users_asset_value.password }}"
-{%  elif secrets_as_variables is defined and secrets_as_variables %}
+{%  elif secrets_as_variables | default(true) | bool %}
   password: "{{ current_users_asset_value.password | replace("$encrypted$", "{{ " + secrets_as_variables_prefix + "controller_users_" + (current_users_asset_value.username | replace(' ', '_') | lower) + "_password }}") }}"
 {%  else %}
   password: "INITIAL"

--- a/roles/filetree_create/templates/eda_credentials.j2
+++ b/roles/filetree_create/templates/eda_credentials.j2
@@ -23,7 +23,7 @@ eda_credentials:
         {{ input.value | indent(width=8) }}
 {%       elif show_encrypted is defined and show_encrypted %}
       {{ input.key }}: {{ input.value }}
-{%       elif secrets_as_variables | default(true) | bool %}
+{%       elif secrets_as_variables | bool %}
       {{ input.key }}: {{ input.value | replace("$encrypted$", "\"{{ " + secrets_as_variables_prefix + "_eda_credentials_" + (eda_credential.name | lower | regex_replace('[^a-z0-9]','_')) + "_" + (input.key | lower | regex_replace('[^a-z0-9]','_')) + " }}\"") }}
 {%       else %}
       {{ input.key }}: {{ input.value | replace("$encrypted$", "\'\'") }}

--- a/roles/filetree_create/templates/eda_credentials.j2
+++ b/roles/filetree_create/templates/eda_credentials.j2
@@ -24,7 +24,7 @@ eda_credentials:
 {%       elif show_encrypted is defined and show_encrypted %}
       {{ input.key }}: {{ input.value }}
 {%       elif secrets_as_variables is defined and secrets_as_variables %}
-      {{ input.key }}: {{ input.value | replace("$encrypted$", "\"{{ " + secrets_as_variables_prefix + "_eda_credentials_" + (eda_credential.name | lower | regex_replace('[^a-z0-9]','_')) + "_" + (input.key | lower | regex_replace('[^a-z0-9]','_')) + " | default('$encrypted$') }}\"") }}
+      {{ input.key }}: {{ input.value | replace("$encrypted$", "\"{{ " + secrets_as_variables_prefix + "_eda_credentials_" + (eda_credential.name | lower | regex_replace('[^a-z0-9]','_')) + "_" + (input.key | lower | regex_replace('[^a-z0-9]','_')) + " }}\"") }}
 {%       else %}
       {{ input.key }}: {{ input.value | replace("$encrypted$", "\'\'") }}
 {%       endif %}

--- a/roles/filetree_create/templates/eda_credentials.j2
+++ b/roles/filetree_create/templates/eda_credentials.j2
@@ -23,7 +23,7 @@ eda_credentials:
         {{ input.value | indent(width=8) }}
 {%       elif show_encrypted is defined and show_encrypted %}
       {{ input.key }}: {{ input.value }}
-{%       elif secrets_as_variables is defined and secrets_as_variables %}
+{%       elif secrets_as_variables | default(true) | bool %}
       {{ input.key }}: {{ input.value | replace("$encrypted$", "\"{{ " + secrets_as_variables_prefix + "_eda_credentials_" + (eda_credential.name | lower | regex_replace('[^a-z0-9]','_')) + "_" + (input.key | lower | regex_replace('[^a-z0-9]','_')) + " }}\"") }}
 {%       else %}
       {{ input.key }}: {{ input.value | replace("$encrypted$", "\'\'") }}

--- a/roles/filetree_create/templates/gateway_users.j2
+++ b/roles/filetree_create/templates/gateway_users.j2
@@ -18,7 +18,7 @@ aap_user_accounts:
     password: "{{ template_overrides_resources.gateway_user[current_user.name].password
                      | default(template_overrides_global.gateway_user.password)
                      | default(current_user.password) }}"
-{%  elif secrets_as_variables | default(true) | bool %}
+{%  elif secrets_as_variables | bool %}
     password: "{{ template_overrides_resources.gateway_user[current_user.name].password
                      | default(template_overrides_global.gateway_user.password)
                      | default(current_user.password) | replace("$encrypted$", "{{ " + secrets_as_variables_prefix + "_gateway_users_" + (_username | replace(' ', '_') | lower) + "_password }}") }}"

--- a/roles/filetree_create/templates/gateway_users.j2
+++ b/roles/filetree_create/templates/gateway_users.j2
@@ -18,7 +18,7 @@ aap_user_accounts:
     password: "{{ template_overrides_resources.gateway_user[current_user.name].password
                      | default(template_overrides_global.gateway_user.password)
                      | default(current_user.password) }}"
-{%  elif secrets_as_variables is defined and secrets_as_variables %}
+{%  elif secrets_as_variables | default(true) | bool %}
     password: "{{ template_overrides_resources.gateway_user[current_user.name].password
                      | default(template_overrides_global.gateway_user.password)
                      | default(current_user.password) | replace("$encrypted$", "{{ " + secrets_as_variables_prefix + "_gateway_users_" + (_username | replace(' ', '_') | lower) + "_password }}") }}"


### PR DESCRIPTION
<!--- markdownlint-disable -->
# What does this PR do?
- Remove `| default('$encrypted$')` as this is very dangerous. Instead, make them define the VAR or dispatch fails!
- Also, set `secrets_as_variable` to `true` as default as this is way safer than ever importing `''` or `'$encrypted$'`

## How should this be tested?
Export credentials.

## Is there a relevant Issue open for this?
N/A

## Other Relevant info, PRs, etc
N/A
