### PR TITLE
check for pah instance. fix conversion issues

### DIFF
--- a/changelogs/fragments/filetree_read_issues.yml
+++ b/changelogs/fragments/filetree_read_issues.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - fix checking issues in the when clauses
+...

--- a/changelogs/fragments/filetree_read_issues.yml
+++ b/changelogs/fragments/filetree_read_issues.yml
@@ -1,4 +1,5 @@
 ---
 bugfixes:
-  - fix checking issues in the when clauses
+  - Adds a check for the PAH instance existence. If this is not available at the AAP target instance, it won't make the filetree_create role to fail
+  - Fixes one problem concatenating string and integer when building a URI
 ...

--- a/roles/filetree_create/tasks/all.yml
+++ b/roles/filetree_create/tasks/all.yml
@@ -17,6 +17,23 @@
       ansible.builtin.debug:
         msg: "The organization {{ organization_filter }} has the ID {{ organization_id }}"
 
+- name: "Block to check if the PAH instance is available"
+  block:
+    - name: "Get if PAH is available"
+      ansible.builtin.uri:
+        url: "https://{{ aap_hostname }}/api/"
+        user: "{{ aap_username }}"
+        password: "{{ aap_password }}"
+        method: GET
+        force_basic_auth: true
+        validate_certs: "{{ aap_validate_certs }}"
+        status_code: 200
+      register: __pah_check
+
+    - name: "Set the fact to control whether the PAH is available or not"
+      ansible.builtin.set_fact:
+        __pah_available: "{{ 'galaxy' in __pah_check.json.apis }}"
+
 - name: Include tasks (block)
   when: "valid_tags | intersect(input_tag) | length > 0"
   block:
@@ -131,28 +148,32 @@
     - name: "Export EDA Rulebook Activations"
       ansible.builtin.include_tasks: "eda_rulebook_activations.yml"
       when: "'eda_rulebook_activations' in input_tag or 'eda' in input_tag or 'all' in input_tag"
-    - name: "Export HUB Namespaces"
-      ansible.builtin.include_tasks: "hub_namespaces.yml"
-      when: "'hub_namespaces' in input_tag or 'hub' in input_tag or 'all' in input_tag"
-    - name: "Export HUB Collections"
-      ansible.builtin.include_tasks: "hub_collections.yml"
-      when: "'hub_collections' in input_tag or 'hub' in input_tag or 'all' in input_tag"
-    - name: "Export HUB Collection Remotes"
-      ansible.builtin.include_tasks: "hub_collection_remotes.yml"
-      when: "'hub_collection_remotes' in input_tag or 'hub' in input_tag or 'all' in input_tag"
-    - name: "Export HUB Collection Repositories"
-      ansible.builtin.include_tasks: "hub_collection_repositories.yml"
-      when: "'hub_collection_repositories' in input_tag or 'hub' in input_tag or 'all' in input_tag"
-    - name: "Export HUB EE Registries"
-      ansible.builtin.include_tasks: "hub_ee_registries.yml"
-      when: "'hub_ee_registries' in input_tag or 'hub' in input_tag or 'all' in input_tag"
-    - name: "Export HUB EE Repositories"
-      ansible.builtin.include_tasks: "hub_ee_repositories.yml"
-      when: "'hub_ee_repositories' in input_tag or 'hub' in input_tag or 'all' in input_tag"
-    - name: "Export HUB EE Images"
-      ansible.builtin.include_tasks: "hub_ee_images.yml"
-      when: "'hub_ee_images' in input_tag or 'hub' in input_tag or 'all' in input_tag"
-    - name: "Export HUB Roles"
-      ansible.builtin.include_tasks: "hub_roles.yml"
-      when: "'hub_roles' in input_tag or 'hub' in input_tag or 'all' in input_tag"
+    - name: "Block to export HUB content when available"
+      when:
+        - __pah_available
+      block:
+        - name: "Export HUB Namespaces"
+          ansible.builtin.include_tasks: "hub_namespaces.yml"
+          when: "'hub_namespaces' in input_tag or 'hub' in input_tag or 'all' in input_tag"
+        - name: "Export HUB Collections"
+          ansible.builtin.include_tasks: "hub_collections.yml"
+          when: "'hub_collections' in input_tag or 'hub' in input_tag or 'all' in input_tag"
+        - name: "Export HUB Collection Remotes"
+          ansible.builtin.include_tasks: "hub_collection_remotes.yml"
+          when: "'hub_collection_remotes' in input_tag or 'hub' in input_tag or 'all' in input_tag"
+        - name: "Export HUB Collection Repositories"
+          ansible.builtin.include_tasks: "hub_collection_repositories.yml"
+          when: "'hub_collection_repositories' in input_tag or 'hub' in input_tag or 'all' in input_tag"
+        - name: "Export HUB EE Registries"
+          ansible.builtin.include_tasks: "hub_ee_registries.yml"
+          when: "'hub_ee_registries' in input_tag or 'hub' in input_tag or 'all' in input_tag"
+        - name: "Export HUB EE Repositories"
+          ansible.builtin.include_tasks: "hub_ee_repositories.yml"
+          when: "'hub_ee_repositories' in input_tag or 'hub' in input_tag or 'all' in input_tag"
+        - name: "Export HUB EE Images"
+          ansible.builtin.include_tasks: "hub_ee_images.yml"
+          when: "'hub_ee_images' in input_tag or 'hub' in input_tag or 'all' in input_tag"
+        - name: "Export HUB Roles"
+          ansible.builtin.include_tasks: "hub_roles.yml"
+          when: "'hub_roles' in input_tag or 'hub' in input_tag or 'all' in input_tag"
 ...

--- a/roles/filetree_create/tasks/controller_credential_input_sources.yml
+++ b/roles/filetree_create/tasks/controller_credential_input_sources.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current input source from the API"
   ansible.builtin.set_fact:
-    credential_input_sources_lookvar: "{{ query('ansible.platform.gateway_api', 'api/controller/v2/credentials/' + __credential_id + '/input_sources/',
+    credential_input_sources_lookvar: "{{ query('ansible.platform.gateway_api', 'api/controller/v2/credentials/' + (__credential_id | string) + '/input_sources/',
                                                 host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs,
                                                 return_all=true, max_objects=query_controller_api_max_objects)
                                        }}"

--- a/roles/filetree_create/templates/controller_settings.j2
+++ b/roles/filetree_create/templates/controller_settings.j2
@@ -2,11 +2,13 @@
 controller_settings:
   - settings:
 {% for key,value in all_settings[0].items() %}
-{% if value is mapping or value | type_debug == "list" %}
+{%   if value is mapping or value | type_debug == "list" %}
 {{ key | indent(width=6, first=True) }}:
 {{ value | to_nice_yaml(indent=2, sort_keys=false) | indent(width=8, first=True) }}
-{%- else %}
+{%   elif key is match('AUTOMATION_ANALYTICS_LAST_ENTRIES') %}
+{{ key | indent(width=6, first=True) }}: {{ value | from_json }}
+{%   else %}
 {{ key | indent(width=6, first=True) }}: "{{ value | replace('True', 'true') | replace('False', 'false') | replace('None', 'null') }}"
-{% endif %}
+{%   endif %}
 {% endfor %}
 ...

--- a/roles/filetree_create/templates/gateway_settings.j2
+++ b/roles/filetree_create/templates/gateway_settings.j2
@@ -1,14 +1,14 @@
 ---
 gateway_settings:
 {% for key,value in all_settings[0].items() %}
-{% if value is mapping or value | type_debug == "list" %}
+{%   if value is mapping or value | type_debug == "list" %}
 {{ key | indent(width=2, first=True) }}:
 {{ value | to_nice_yaml(indent=2, sort_keys=false) | indent(width=4, first=True) }}
-{%- elif key == "jwt_public_key" %}{#
+{%-  elif key == "jwt_public_key" %}{#
 {{ key | indent(width=2, first=True) }}: |-
 {{ value | indent(width=4, first=True) }}
-#}{%- else %}
+#}{%-  else %}
 {{ key | indent(width=2, first=True) }}: "{{ value | replace('True', 'true') | replace('False', 'false') | replace('None', 'null') }}"
-{% endif %}
+{%   endif %}
 {% endfor %}
 ...


### PR DESCRIPTION
<!--- markdownlint-disable -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
Adds a check for the PAH instance existence. If this is not available at the AAP target instance, it won't make the `filetree_create` role to fail.
Also fixes one problem concatenating `string` and `integer` when building a URI.
## How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
Manually tested
## Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #187

## Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
N/A