### PR TITLE
Fix the wrong variable names

### DIFF
--- a/changelogs/fragments/filetree_create_controller_hosts.yml
+++ b/changelogs/fragments/filetree_create_controller_hosts.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fix a variable in the filetree_create role that was causing wrong output contents for controller_hosts
+...

--- a/roles/filetree_create/tasks/controller_hosts.yml
+++ b/roles/filetree_create/tasks/controller_hosts.yml
@@ -28,7 +28,7 @@
         marker: ""
         block: "{{ lookup('template', 'templates/controller_hosts.j2') }}"
       vars:
-        first_group: "{{ not (__hosts_file.stat.exists | bool) }}"
+        first_host: "{{ not (__hosts_file.stat.exists | bool) }}"
 
     - name: "Remove all the blank lines introduced by the last task"
       ansible.builtin.lineinfile:

--- a/roles/filetree_create/templates/controller_hosts.j2
+++ b/roles/filetree_create/templates/controller_hosts.j2
@@ -1,4 +1,4 @@
-{% if first_hosts | default(true) | bool %}
+{% if first_host | default(true) | bool %}
 ---
 controller_hosts:
 {% endif %}


### PR DESCRIPTION
<!--- markdownlint-disable -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
Fix a variable in the filetree_create role that was causing wrong output contents for controller_hosts.
## How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
Manually tested.
## Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #190 

## Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
N/A