### PR TITLE
Fix the exportation of the controller_settings 

### DIFF
--- a/changelogs/fragments/filetree_create_controller_settings.yaml
+++ b/changelogs/fragments/filetree_create_controller_settings.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fix the exportation of the controller_settings that was failing when the parameter AUTOMATION_ANALYTICS_LAST_ENTRIES was empty
+...

--- a/roles/filetree_create/templates/controller_settings.j2
+++ b/roles/filetree_create/templates/controller_settings.j2
@@ -1,11 +1,12 @@
 ---
 controller_settings:
   - settings:
+{#      {{ all_settings[0] }} #}
 {% for key,value in all_settings[0].items() %}
 {%   if value is mapping or value | type_debug == "list" %}
 {{ key | indent(width=6, first=True) }}:
 {{ value | to_nice_yaml(indent=2, sort_keys=false) | indent(width=8, first=True) }}
-{%   elif key is match('AUTOMATION_ANALYTICS_LAST_ENTRIES') %}
+{%   elif key is match('AUTOMATION_ANALYTICS_LAST_ENTRIES') and value | length > 0 %}
 {{ key | indent(width=6, first=True) }}: "{{ value | from_json }}"
 {%   else %}
 {{ key | indent(width=6, first=True) }}: "{{ value | replace('True', 'true') | replace('False', 'false') | replace('None', 'null') }}"

--- a/roles/filetree_create/templates/controller_settings.j2
+++ b/roles/filetree_create/templates/controller_settings.j2
@@ -1,7 +1,6 @@
 ---
 controller_settings:
   - settings:
-{#      {{ all_settings[0] }} #}
 {% for key,value in all_settings[0].items() %}
 {%   if value is mapping or value | type_debug == "list" %}
 {{ key | indent(width=6, first=True) }}:


### PR DESCRIPTION


<!--- markdownlint-disable -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
Fix the exportation of the controller_settings that was failing when the parameter AUTOMATION_ANALYTICS_LAST_ENTRIES was empty.
## How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
Manually tested
## Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
<!--- resolves #[number] -->
N/A
## Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
N/A