### PR TITLE
generate the controller_settings output as a dict instead of a list

### DIFF
--- a/changelogs/fragments/filtree_create_controller_settings.yaml
+++ b/changelogs/fragments/filtree_create_controller_settings.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - infra.aap_configuration_extended.filetree_create now generates a dict instead of a list for controller_settings, so infra.aap_configuration.dispatch can use it directly
+...

--- a/roles/filetree_create/templates/controller_settings.j2
+++ b/roles/filetree_create/templates/controller_settings.j2
@@ -1,14 +1,14 @@
 ---
 controller_settings:
-  - settings:
+  settings:
 {% for key,value in all_settings[0].items() %}
 {%   if value is mapping or value | type_debug == "list" %}
-{{ key | indent(width=6, first=True) }}:
-{{ value | to_nice_yaml(indent=2, sort_keys=false) | indent(width=8, first=True) }}
+{{ key | indent(width=4, first=True) }}:
+{{ value | to_nice_yaml(indent=2, sort_keys=false) | indent(width=6, first=True) }}
 {%   elif key is match('AUTOMATION_ANALYTICS_LAST_ENTRIES') and value | length > 0 %}
-{{ key | indent(width=6, first=True) }}: "{{ value | from_json }}"
+{{ key | indent(width=4, first=True) }}: "{{ value | from_json }}"
 {%   else %}
-{{ key | indent(width=6, first=True) }}: "{{ value | replace('True', 'true') | replace('False', 'false') | replace('None', 'null') }}"
+{{ key | indent(width=4, first=True) }}: "{{ value | replace('True', 'true') | replace('False', 'false') | replace('None', 'null') }}"
 {%   endif %}
 {% endfor %}
 ...


### PR DESCRIPTION
<!--- markdownlint-disable -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
Generate the controller_settings output as a dict instead of a list to solve the issue #202 
## How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
Manually tested
## Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #202 

## Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
N/A