### PR TITLE
Fix the output for when unified_job_template is not defined in a work…

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -10,7 +10,7 @@ exclude_paths:
   - 'changelogs/'
   - 'tests/templated_role_example'
   - .ansible/
-parseable: true
+# parseable: true
 use_default_rules: true
 strict: true
 profile: production

--- a/changelogs/fragments/filetree_create_fixes.yaml
+++ b/changelogs/fragments/filetree_create_fixes.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - Fix an issue with the notification templates output where an integer can't be concatenated to a string when forming the URL (ansible >= 4.20.1)
+  - Fix the output of the workflow job templates when a node have it's unified_job_template field not defined (the original JT has been deleted but the WF has not been updated accordingly)
+...

--- a/roles/filetree_create/tasks/controller_team_roles.yml
+++ b/roles/filetree_create/tasks/controller_team_roles.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Team Roles from the API"
   ansible.builtin.set_fact:
-    team_roles_lookvar: "{{ query('ansible.platform.gateway_api', 'api/controller/v2/teams/' + teamid + '/roles/',
+    team_roles_lookvar: "{{ query('ansible.platform.gateway_api', 'api/controller/v2/teams/' + (teamid | string) + '/roles/',
                                   host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs,
                                   return_all=true, max_objects=query_controller_api_max_objects)
                          }}"

--- a/roles/filetree_create/templates/controller_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/controller_workflow_job_templates.j2
@@ -18,26 +18,30 @@ controller_workflows:
         inventory: "{{ node.summary_fields.inventory.name }}"
 {% endif %}
         workflow_job_template: "{{ node.summary_fields.workflow_job_template.name }}"
-{% if node.summary_fields.unified_job_template.unified_job_type == 'workflow_approval' %}
+{% if node.summary_fields.unified_job_template is defined %}
+{%   if node.summary_fields.unified_job_template.unified_job_type == 'workflow_approval' %}
         approval_node:
           description: "{{ node.summary_fields.unified_job_template.description }}"
           name: "{{ node.summary_fields.unified_job_template.name }}"
           timeout: {{ node.summary_fields.unified_job_template.timeout }}
-{% else %}
-        unified_job_template: "{{ node.summary_fields.unified_job_template.name | default('ToDo: The node is pointing to a deleted Job Template') }}"
-{%   if node.verbosity != None %}
-        verbosity: "{{ node.verbosity }}"
 {%   else %}
+        unified_job_template: "{{ node.summary_fields.unified_job_template.name | default('ToDo: The node is pointing to a deleted Job Template') }}"
+{%     if node.verbosity != None %}
+        verbosity: "{{ node.verbosity }}"
+{%     else %}
 {%     set jt_var = query('ansible.platform.gateway_api', 'api/controller/v2/job_templates',
                           query_params={'name': node.summary_fields.unified_job_template.name},
                           host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs,
                           return_all=true, max_objects=query_controller_api_max_objects) %}
-{%     if jt_var | length > 0 %}
-{%       if jt_var[0]['ask_verbosity_on_launch'] %}
+{%       if jt_var | length > 0 %}
+{%         if jt_var[0]['ask_verbosity_on_launch'] %}
         verbosity: "{{ jt_var[0]['verbosity'] }}"
+{%         endif %}
 {%       endif %}
 {%     endif %}
 {%   endif %}
+{% else %}
+        unified_job_template: "ToDo: The node is pointing to a deleted Job Template"
 {% endif %}
 {% if node.limit is defined %}
         limit: "{{ node.limit }}"


### PR DESCRIPTION
<!--- markdownlint-disable -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
* Fix an issue with the notification templates output where an integer can't be concatenated to a string when forming the URL (ansible >= 4.20.1)
* Fix the output of the workflow job templates when a node have it's unified_job_template field not defined (the original JT has been deleted but the WF has not been updated accordingly)

## How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
Manually tested
## Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
<!-- resolves #[number] -->
N/A
## Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
N/A