### PR TITLE
Fix error with org id in eda_rulebook_activations

### DIFF
--- a/changelogs/fragments/filetree_create_eda_rulebook_activations.yaml
+++ b/changelogs/fragments/filetree_create_eda_rulebook_activations.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Change decision_environment_id to organization_id in eda_rulebook_activations.yml to fix error when exporting rulebook activations
+...

--- a/roles/filetree_create/tasks/eda_rulebook_activations.yml
+++ b/roles/filetree_create/tasks/eda_rulebook_activations.yml
@@ -94,7 +94,7 @@
             rulebook_activation_id: "{{ current_rulebook_activations_asset_value.id }}"
             rulebook_activation_name: "{{ current_rulebook_activations_asset_value.name | regex_replace('/', '_') }}"
             __dest: "{{ output_path }}/{{ rulebook_activation_organization | regex_replace('/', '_') }}/{{ filetree_create_eda_rulebook_activations }}/{{ (rulebook_activation_id ~ '_') if omit_id is not defined else '' }}{{ rulebook_activation_name | regex_replace('/', '_') }}.yaml"
-            query_organization_name: "{{ (query('ansible.platform.gateway_api', 'api/eda/v1/organizations/' + current_rulebook_activations_asset_value.decision_environment_id | string,
+            query_organization_name: "{{ (query('ansible.platform.gateway_api', 'api/eda/v1/organizations/' + current_rulebook_activations_asset_value.organization_id | string,
                                                 host=aap_hostname, oauth_token=aap_oauthtoken, verify_ssl=aap_validate_certs,
                                                 return_all=true, max_objects=query_eda_api_max_objects) | first).name
                                      }}"


### PR DESCRIPTION
# What does this PR do?
When creating non-flat output (i.e. flatten_output: false), the block that writes out rulebook activations mistakenly uses the decision_environment_id instead of the organization_id.

This results in errors if the decision_environment_id is not coincidentally equal to the organization_id for a certain rulebook activation.

For simple deployments (and probably for tests) the decision_environment_id "1" is the default decision environment, and the organization_id "1" is the default organization. Therefore, the error was probably missed during tests that use just a single org and don't use custom DEs.

This commit fixes this mistake and makes non-flat output work when there are rulebook activations in a custom organizations that use a custom decision environment.

## How should this be tested?
Create a new organization and add a rulebook activation to it and / or create a custom decision environment and add it to a rulebook activation. That way either the organization id will be >1 and thus not accidentally be the same as the default decision environment's id, or the decision environment id >1 and not accidentally the same as the default organization's id.

The code of the fix is quite obvious though.

## Is there a relevant Issue open for this?
No

