### PR TITLE
Update no_log variable for secure logging configuration

### DIFF
--- a/changelogs/fragments/filetree_create_fix_no_log_var.yaml
+++ b/changelogs/fragments/filetree_create_fix_no_log_var.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "filetree_create - gateway_role_definitions.yml‎ - Fix no_log var undefined"

--- a/roles/filetree_create/tasks/gateway_role_definitions.yml
+++ b/roles/filetree_create/tasks/gateway_role_definitions.yml
@@ -9,7 +9,7 @@
   vars:
     query_params:
       managed: false
-  no_log: "{{ configuration_filetree_create_secure_logging }}"
+  no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
 - name: "Create the output directory for Gateway Role Definitions: {{ output_path }}"
   ansible.builtin.file:


### PR DESCRIPTION
<!--- markdownlint-disable -->
# What does this PR do?
Fix the `no_log` variable for the Gateway Role Definitions task file

## How should this be tested?
Test by exporting Gateway Role Definitions

## Is there a relevant Issue open for this?
N/A

## Other Relevant info, PRs, etc
N/A
