### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/issue-close-inactive.yml
+++ b/.github/workflows/issue-close-inactive.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   close-inactive-issues:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: close-issues
         uses: actions-cool/issues-helper@v3

--- a/.github/workflows/issue-find-inactive.yml
+++ b/.github/workflows/issue-find-inactive.yml
@@ -1,6 +1,9 @@
 ---
 # https://github.com/marketplace/actions/issues-helper
 name: Check inactive
+permissions:
+  contents: read
+  issues: write
 
 on:
   schedule:

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   issue-labeled:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Create comment
         uses: actions-cool/issues-helper@v3

--- a/.github/workflows/issue-remove-inactive.yml
+++ b/.github/workflows/issue-remove-inactive.yml
@@ -8,6 +8,9 @@ on:
   issue_comment:
     types: [created, edited]
 
+permissions:
+  issues: write
+
 jobs:
   remove-inactive:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   release:
     name: Release Collection to galaxy/AH
+    permissions:
+      contents: read
     uses: "redhat-cop/ansible_collections_tooling/.github/workflows/release_pipeline_dual_crc.yml@main"
     with:
       # Galaxy Publish

--- a/.github/workflows/update_pre_commit.yml
+++ b/.github/workflows/update_pre_commit.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: "0 5 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     uses: "redhat-cop/ansible_collections_tooling/.github/workflows/update_precommit.yml@main"


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/aap_configuration_extended/security/code-scanning/7](https://github.com/redhat-cop/aap_configuration_extended/security/code-scanning/7)

In general, the fix is to add an explicit `permissions` block that grants only the minimal rights needed for this workflow. Since this workflow simply schedules and invokes a reusable workflow that updates pre-commit configuration, the most conservative safe default is to set `contents: read` at the workflow (top) level so that all jobs inherit read-only repository access, unless a job needs more. This documents the intended permission level and protects against permissive repository defaults or future changes.

Concretely, in `.github/workflows/update_pre_commit.yml`, add a `permissions:` section near the top of the file (for example, directly after the `on:` block) specifying `contents: read`. This will apply to the `pre-commit` job since it has no job-level `permissions`. No imports or other definitions are needed because this is purely a YAML configuration change for the GitHub Actions workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
