### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,6 +2,8 @@
 # This workflow action will run pre-commit, which will execute ansible and yaml linting
 # See .pre-commit-config.yaml for what hooks are executed
 name: pre-commit tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/aap_configuration_extended/security/code-scanning/13](https://github.com/redhat-cop/aap_configuration_extended/security/code-scanning/13)

To fix the problem, explicitly declare `permissions` for the `GITHUB_TOKEN` either at the workflow root (applies to all jobs) or per job, granting only the minimum required access. Since this workflow appears to run linting and pre-commit checks and to use a reusable workflow, a conservative default is to set `contents: read` at the workflow level, which is sufficient for checking out code and most analysis tasks. If the reusable workflow or publishing step requires additional write permissions, they should be added narrowly (e.g., `contents: write` or `packages: write`), but we cannot infer such requirements from the provided snippet, so we keep it read-only.

The single best minimally invasive fix, without changing existing behavior more than necessary, is to add a top-level `permissions` block specifying `contents: read` just after the `name:` (or before `on:`). This documents the intended access and constrains the token for all jobs, including `approve_run` and `pre-commit_and_sanity`. No imports or additional definitions are needed, as this is purely a YAML configuration change within `.github/workflows/pre-commit.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
