### PR TITLE
fix: add tox-ansible.ini passenv and run default pre-commit hooks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -30,6 +30,12 @@ jobs:
           python-version: "3.x"
       - name: Run default pre-commit hooks
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        env:
+          ANSIBLE_GALAXY_SERVER_LIST: certified,galaxy
+          ANSIBLE_GALAXY_SERVER_CERTIFIED_URL: https://console.redhat.com/api/automation-hub/content/published/
+          ANSIBLE_GALAXY_SERVER_CERTIFIED_AUTH_URL: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+          ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN: ${{ secrets.CRC_PUBLISH_KEY }}
+          ANSIBLE_GALAXY_SERVER_GALAXY_URL: https://galaxy.ansible.com/api/
       - name: Run sanity (manual stage)
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,7 +28,10 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.x"
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - name: Run default pre-commit hooks
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - name: Run sanity (manual stage)
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: --hook-stage manual sanity --all-files
         env:


### PR DESCRIPTION
## Summary

- **Add `tox-ansible.ini`** with `pass_env = ANSIBLE_GALAXY_SERVER*` so tox forwards the Automation Hub credentials into the isolated venv where `ade install` / `ansible-galaxy collection install` runs. Without this, the env vars set on the workflow step are blocked by tox's environment isolation.
- **Split the pre-commit CI into two steps**: the first runs all default-stage hooks (ansible-lint, changelog, galaxy-importer, etc.), the second runs the manual-stage sanity hook with the Galaxy server env vars.

## Problem

The sanity hook fails with `Failed to resolve the requested dependencies map. Could not satisfy the following requirements: * ansible.controller:>=4.6.0` because tox does not pass through `ANSIBLE_GALAXY_SERVER_*` env vars by default — its `pass_env` only includes `GITHUB_TOKEN`.

Additionally, the current workflow only runs `--hook-stage manual sanity`, skipping all the default-stage hooks entirely.

## Test plan

- [ ] Verify default hooks (ansible-lint, changelog, etc.) run in CI
- [ ] Verify sanity hook resolves `ansible.controller` from Automation Hub successfully


Made with [Cursor](https://cursor.com)