### PR TITLE
fix(ci): use console.redhat.com for Automation Hub Galaxy URL

### DIFF
--- a/.github/workflows/release_auto.yml
+++ b/.github/workflows/release_auto.yml
@@ -249,7 +249,7 @@ jobs:
       - name: Publish to Automation Hub
         env:
           ANSIBLE_GALAXY_SERVER_LIST: rh_automation_hub
-          ANSIBLE_GALAXY_SERVER_RH_AUTOMATION_HUB_URL: https://cloud.redhat.com/api/automation-hub/
+          ANSIBLE_GALAXY_SERVER_RH_AUTOMATION_HUB_URL: https://console.redhat.com/api/automation-hub/
           ANSIBLE_GALAXY_SERVER_RH_AUTOMATION_HUB_AUTH_URL: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
           ANSIBLE_GALAXY_SERVER_RH_AUTOMATION_HUB_TOKEN: ${{ secrets.CRC_PUBLISH_KEY }}
         run: |

--- a/changelogs/fragments/release_auto-automation-hub-console-url.yml
+++ b/changelogs/fragments/release_auto-automation-hub-console-url.yml
@@ -1,0 +1,4 @@
+---
+trivial:
+  - >-
+    Update the Automation Hub API base URL in ``release_auto`` workflow for publishing.


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Updates the **`release_auto`** workflow so **`ANSIBLE_GALAXY_SERVER_RH_AUTOMATION_HUB_URL`** uses **`https://console.redhat.com/api/automation-hub/`** instead of **`https://cloud.redhat.com/api/automation-hub/`** when publishing to Red Hat Automation Hub.

The `cloud` hostname remains valid, but `console` matches current Red Hat guidance for the hybrid cloud console and avoids leaning on a URL that may change over time.

# How should this be tested?

There is no automated test that exercises a real Galaxy publish from CI; validation is by review of the workflow change.

1. Open `.github/workflows/release_auto.yml` and confirm the Automation Hub Galaxy URL is `https://console.redhat.com/api/automation-hub/`.
2. Confirm no other workflow steps for this publish path still reference `https://cloud.redhat.com/api/automation-hub/`.

# Is there a relevant Issue open for this?

No.

# Other Relevant info, PRs, etc

Red Hat documents the subscription services transition to the hybrid cloud console in the KB artice [Transition of subscription services to the hybrid cloud console](https://access.redhat.com/articles/transition_of_subscription_services_to_the_hybrid_cloud_console).

