### PR TITLE
fix: align controller_export_diff DOCUMENTATION with AUTH_ARGSPEC

### DIFF
--- a/plugins/modules/controller_export_diff.py
+++ b/plugins/modules/controller_export_diff.py
@@ -109,25 +109,25 @@ options:
         - Include items in the original compare list in the output, and set state to 'present'
       type: bool
       default: True
-    aap_hostname:
+    controller_host:
       description:
       - URL to your Automation Platform Controller instance.
       - If value not set, will try environment variable C(CONTROLLER_HOST) and then config files
       - If value not specified by any means, the value of C(127.0.0.1) will be used
       type: str
-      aliases: [ controller_host, tower_host ]
-    aap_username:
+      aliases: [ tower_host, aap_hostname ]
+    controller_username:
       description:
       - Username for your controller instance.
       - If value not set, will try environment variable C(CONTROLLER_USERNAME) and then config files
       type: str
-      aliases: [ controller_username, tower_username ]
-    aap_password:
+      aliases: [ tower_username, aap_username ]
+    controller_password:
       description:
       - Password for your controller instance.
       - If value not set, will try environment variable C(CONTROLLER_PASSWORD) and then config files
       type: str
-      aliases: [ controller_password, tower_password ]
+      aliases: [ tower_password, aap_password ]
     aap_token:
       description:
       - The OAuth token to use.
@@ -136,29 +136,28 @@ options:
       - A dictionary structure as returned by the token module.
       - If value not set, will try environment variable C(CONTROLLER_OAUTH_TOKEN) and then config files
       type: raw
-      aliases: [ controller_oauthtoken ]
-    aap_validate_certs:
+    validate_certs:
       description:
       - Whether to allow insecure connections to AWX.
       - If C(no), SSL certificates will not be validated.
       - This should only be used on personally controlled sites using self-signed certificates.
       - If value not set, will try environment variable C(CONTROLLER_VERIFY_SSL) and then config files
       type: bool
-      aliases: [ validate_certs, tower_verify_ssl ]
-    aap_request_timeout:
+      aliases: [ tower_verify_ssl, aap_validate_certs ]
+    request_timeout:
       description:
       - Specify the timeout Ansible should use in requests to the controller host.
       - Defaults to 10s, but this is handled by the shared module_utils code
       - This option requires awx.awx>=22.7.0 or equivalent ansible.controller collection
       type: float
-      aliases: [ request_timeout ]
+      aliases: [ aap_request_timeout ]
       version_added: "2.6.0"
     controller_config_file:
       description:
       - Path to the controller config file.
       - If provided, the other locations for config files will not be considered.
       type: path
-      aliases: [tower_config_file]
+      aliases: [ tower_config_file ]
 requirements:
   - "awxkit >= 9.3.0"
   - awx.awx or ansible.controller collection


### PR DESCRIPTION
## Summary

Fixes the upstream `pre-commit and sanity tests` CI failure caused by `validate-modules` sanity errors in `controller_export_diff.py`.

The DOCUMENTATION block did not match the actual `AUTH_ARGSPEC` from `ansible.controller`'s `ControllerAWXKitModule`:

- **`controller_oauthtoken`** was listed as an alias for `aap_token`, but this alias does not exist in the argument_spec — causing `nonexistent-parameter-documented`
- **`aap_token`** documentation listed aliases `['aap_token', 'controller_oauthtoken']` while the argument_spec only has `['aap_token']` — causing `parameter-documented-aliases-differ`
- Several parameters used `aap_*` names as primaries (e.g. `aap_hostname`, `aap_validate_certs`) when the actual primaries in the argument_spec are `controller_host`, `validate_certs`, `request_timeout`, etc.

All documented parameter names and aliases now match the `AUTH_ARGSPEC` exactly.

## Test plan

- [x] `ansible-lint --offline plugins/modules/controller_export_diff.py` passes locally
- [ ] CI `validate-modules` sanity test passes (currently fails on every run)
