### PR TITLE
fix: add missing aap_token aliases to controller_export_diff docs

### DIFF
--- a/changelogs/fragments/fix_controller_export_diff_docs.yaml
+++ b/changelogs/fragments/fix_controller_export_diff_docs.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - controller_export_diff - Added missing ``oauth_token``, ``controller_oauthtoken``, and ``tower_oauthtoken`` aliases for the ``aap_token`` parameter to match the current ``ansible.controller`` AUTH_ARGSPEC.
+...


### PR DESCRIPTION
## Summary

Follow-up to #279. The `ansible.controller` collection's `AUTH_ARGSPEC` added three aliases to `aap_token` (`oauth_token`, `controller_oauthtoken`, `tower_oauthtoken`) that were not present when #279 was written. This causes `validate-modules` sanity failures on every CI run:

- `undocumented-parameter` for `controller_oauthtoken`, `oauth_token`, `tower_oauthtoken`
- `parameter-documented-aliases-differ` for `aap_token`

This adds the missing aliases to the DOCUMENTATION block and includes a changelog fragment.

## Test plan

- [ ] CI `validate-modules` sanity test passes
