### PR TITLE
fix: restore single pre-commit CI check with Python matrix

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - run: echo "Approval granted."
 
-  pre-commit:
+  pre-commit-tests:
     needs: approve_run
     runs-on: ubuntu-latest
     strategy:
@@ -60,3 +60,11 @@ jobs:
           ANSIBLE_GALAXY_SERVER_CERTIFIED_AUTH_URL: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
           ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN: ${{ secrets.CRC_PUBLISH_KEY }}
           ANSIBLE_GALAXY_SERVER_GALAXY_URL: https://galaxy.ansible.com/api/
+
+  # Single check name for branch protection (matrix jobs report as pre-commit-tests (3.x)).
+  pre-commit:
+    needs: pre-commit-tests
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() && needs.pre-commit-tests.result == 'success' }}
+    steps:
+      - run: echo "All pre-commit matrix jobs passed."

--- a/changelogs/fragments/fix_python_version_ansible_devel.yaml
+++ b/changelogs/fragments/fix_python_version_ansible_devel.yaml
@@ -2,4 +2,5 @@
 bugfixes:
   - fix CI workflow for Ansible Core devel version, that requires python >=3.13
   - add tox-ansible.ini to skip sanity environments that pair ansible-core devel with Python <3.13
+  - restore a single pre-commit CI check for branch protection when using a Python matrix
 ...

--- a/changelogs/fragments/fix_python_version_ansible_devel.yaml
+++ b/changelogs/fragments/fix_python_version_ansible_devel.yaml
@@ -3,4 +3,5 @@ bugfixes:
   - fix CI workflow for Ansible Core devel version, that requires python >=3.13
   - add tox-ansible.ini to skip sanity environments that pair ansible-core devel with Python <3.13
   - restore a single pre-commit CI check for branch protection when using a Python matrix
+  - run sanity on Python 3.12, 3.13, and 3.14 in CI
 ...


### PR DESCRIPTION
## Summary
- Rename the matrix CI job to `pre-commit-tests` so Python 3.12 and 3.13 sanity runs stay parallel.
- Add a `pre-commit` aggregator job that depends on the matrix and reports the single status check required by branch protection.

## Context
After adding a Python matrix to the `pre-commit` job, GitHub only reported checks named `pre-commit (3.12)` and `pre-commit (3.13)`. Branch protection still expects a check named `pre-commit`, leaving PRs stuck on "Waiting for status to be reported" even when the matrix jobs succeeded.

## Test plan
- [ ] CI reports `pre-commit and sanity tests / pre-commit` as successful
- [ ] Matrix jobs `pre-commit-tests (3.12)` and `pre-commit-tests (3.13)` still pass
- [ ] Required branch protection check `pre-commit` is satisfied on the PR


Made with [Cursor](https://cursor.com)