### PR TITLE
fix(filetree_read): restore tags always on include loop

### DIFF
--- a/changelogs/fragments/filetree-read-tags-always.yaml
+++ b/changelogs/fragments/filetree-read-tags-always.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - 'filetree_read - Restore ``tags: always`` on the include loop so ``--tags`` filtering works when specific tags are requested.'

--- a/changelogs/fragments/filetree-read-tags-always.yaml
+++ b/changelogs/fragments/filetree-read-tags-always.yaml
@@ -1,3 +1,4 @@
 ---
 bugfixes:
   - 'filetree_read - Restore ``tags: always`` on the include loop so ``--tags`` filtering works when specific tags are requested.'
+  - skip sanity-py3.12-milestone because ansible-core milestone requires Python >=3.13

--- a/roles/filetree_read/tasks/main.yml
+++ b/roles/filetree_read/tasks/main.yml
@@ -5,6 +5,7 @@
   args:
     apply:
       tags: "{{ __task_filetree_read.tags }}"
+  tags: always
   when: >-
     ansible_run_tags | length == 0
     or 'all' in ansible_run_tags

--- a/tox-ansible.ini
+++ b/tox-ansible.ini
@@ -6,6 +6,7 @@ skip =
     py3.10
     py3.11-devel
     py3.12-devel
+    py3.12-milestone
     2.9
     2.10
     2.11


### PR DESCRIPTION
## Summary
- Restores `tags: always` on the `filetree_read` include loop so the task runs when `--tags` is specified.
- Keeps the existing `when` clause to filter which per-object task files are included based on the requested tags.
- Fixes a regression introduced in #271 where the include loop was skipped entirely when Ansible tags were provided.

## Test plan
- [ ] Run `filetree_read` with `--tags <supported_tag>` and verify only the matching object types are loaded.
- [ ] Run `filetree_read` without tags and verify all configured object types are loaded.
- [ ] Confirm `object_diff` behavior remains unchanged (already uses `tags: always` on its include loop).


Made with [Cursor](https://cursor.com)