### PR TITLE
fix: apply ci-approved label via github-script in approval workflow

### DIFF
--- a/.github/workflows/pre-commit-approve.yml
+++ b/.github/workflows/pre-commit-approve.yml
@@ -38,9 +38,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-apply approval label
-        run: gh pr edit ${{ github.event.pull_request.number }} --add-label "ci-approved"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const label = 'ci-approved';
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            if (!labels.includes(label)) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] });
+            }
 
   manual-approval:
     needs: check-changes
@@ -54,6 +61,13 @@ jobs:
         run: echo "Approval granted."
 
       - name: Apply approval label after manual review
-        run: gh pr edit ${{ github.event.pull_request.number }} --add-label "ci-approved"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const label = 'ci-approved';
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            if (!labels.includes(label)) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] });
+            }

--- a/changelogs/fragments/ci-approve-label-github-script.yml
+++ b/changelogs/fragments/ci-approve-label-github-script.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - apply the ci-approved label via actions/github-script in the trusted approval
+    workflow instead of gh pr edit, which fails without a git checkout


### PR DESCRIPTION
## Summary

- Replace `gh pr edit` with `actions/github-script` in `pre-commit approval` to add the `ci-approved` label.
- The approval workflow intentionally avoids checkout (no pwn-request risk); `gh` fails without a local git repository, especially in `manual-approval`.
- `actions/github-script` uses the workflow token automatically — no explicit `GH_TOKEN` is needed.
- `pre-commit and sanity tests` already listens for the `labeled` event and runs when `ci-approved` is present (from #290).

## Test plan

- [ ] Open or sync a trusted collaborator PR (no `.github` changes) and confirm `auto-approve` adds `ci-approved` and tests run.
- [ ] Open or sync an external PR and confirm `manual-approval` waits for `requires-approval` reviewers, then adds the label and tests run.
- [ ] Confirm `pre-commit-tests` checks appear on the PR and report success/failure.