### PR TITLE
fix: coordinate PR CI tests with approval-gate polling

### DIFF
--- a/.github/workflows/pre-commit-approve.yml
+++ b/.github/workflows/pre-commit-approve.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   check-changes:
@@ -37,17 +37,8 @@ jobs:
       needs.check-changes.outputs.github_modified == 'false'
     runs-on: ubuntu-latest
     steps:
-      - name: Auto-apply approval label
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        with:
-          script: |
-            const label = 'ci-approved';
-            const { owner, repo } = context.repo;
-            const issue_number = context.payload.pull_request.number;
-            const labels = context.payload.pull_request.labels.map(l => l.name);
-            if (!labels.includes(label)) {
-              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] });
-            }
+      - name: Trusted collaborator PR approved automatically
+        run: echo "Trusted collaborator PR approved automatically."
 
   manual-approval:
     needs: check-changes
@@ -59,15 +50,3 @@ jobs:
     steps:
       - name: Approval granted
         run: echo "Approval granted."
-
-      - name: Apply approval label after manual review
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        with:
-          script: |
-            const label = 'ci-approved';
-            const { owner, repo } = context.repo;
-            const issue_number = context.payload.pull_request.number;
-            const labels = context.payload.pull_request.labels.map(l => l.name);
-            if (!labels.includes(label)) {
-              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] });
-            }

--- a/.github/workflows/pre-commit-tests.yml
+++ b/.github/workflows/pre-commit-tests.yml
@@ -1,12 +1,12 @@
 ---
 # Untrusted code execution: pull_request (fork PRs have no secrets).
-# Ansible collections from Automation Hub are restored from the default-branch
-# cache, which trusted push/schedule runs populate with CRC_PUBLISH_KEY.
+# Pull request runs wait in approval-gate until pre-commit approval completes.
+# Push/schedule runs populate the Ansible collections cache for external PRs.
 name: pre-commit and sanity tests
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
   push:
     branches: [devel]
   schedule:
@@ -18,19 +18,124 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
+  actions: read
 
 jobs:
+  approval-gate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    outputs:
+      approved: ${{ steps.check.outputs.approved }}
+    steps:
+      - name: Wait for pre-commit approval workflow
+        id: check
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+            const pollIntervalMs = 30_000;
+            const timeoutMs = 360 * 60 * 1000;
+            const deadline = Date.now() + timeoutMs;
+
+            const { owner, repo } = context.repo;
+            const pullRequest = context.payload.pull_request;
+            const headSha = pullRequest.head.sha;
+
+            if (pullRequest.base.ref !== 'devel') {
+              core.setFailed(
+                `Pull request #${pullRequest.number} targets ${pullRequest.base.ref}, expected devel`,
+              );
+              core.setOutput('approved', 'false');
+              return;
+            }
+
+            async function getLatestApprovalRun() {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner,
+                repo,
+                workflow_id: 'pre-commit-approve.yml',
+                head_sha: headSha,
+                event: 'pull_request_target',
+                per_page: 5,
+              });
+              return data.workflow_runs[0];
+            }
+
+            async function hasSuccessfulApprovalJob(runId) {
+              const { data: jobsResponse } = await github.rest.actions.listJobsForWorkflowRun({
+                owner,
+                repo,
+                run_id: runId,
+              });
+              return jobsResponse.jobs.find(
+                (job) =>
+                  (job.name === 'auto-approve' || job.name === 'manual-approval') &&
+                  job.conclusion === 'success',
+              );
+            }
+
+            while (Date.now() < deadline) {
+              const approvalRun = await getLatestApprovalRun();
+
+              if (!approvalRun) {
+                core.info('Waiting for pre-commit approval workflow to start...');
+                await sleep(pollIntervalMs);
+                continue;
+              }
+
+              if (approvalRun.status !== 'completed') {
+                core.info(
+                  `Waiting for pre-commit approval workflow ${approvalRun.id} (${approvalRun.status})...`,
+                );
+                await sleep(pollIntervalMs);
+                continue;
+              }
+
+              if (approvalRun.conclusion !== 'success') {
+                core.setFailed(
+                  `pre-commit approval workflow ${approvalRun.id} concluded with ${approvalRun.conclusion}`,
+                );
+                core.setOutput('approved', 'false');
+                return;
+              }
+
+              const approvalJob = await hasSuccessfulApprovalJob(approvalRun.id);
+              if (!approvalJob) {
+                core.setFailed(
+                  `pre-commit approval workflow ${approvalRun.id} completed without a successful approval job`,
+                );
+                core.setOutput('approved', 'false');
+                return;
+              }
+
+              core.notice(
+                `Approved by ${approvalJob.name} in workflow run ${approvalRun.id}`,
+                { title: 'CI approval gate' },
+              );
+              core.setOutput('approved', 'true');
+              return;
+            }
+
+            core.setFailed('Timed out waiting for pre-commit approval workflow to complete');
+            core.setOutput('approved', 'false');
+
   pre-commit-tests:
+    needs: approval-gate
     runs-on: ubuntu-latest
     if: >
-      github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'ci-approved')
+      always() &&
+      !cancelled() &&
+      (github.event_name == 'push' ||
+       github.event_name == 'schedule' ||
+       (github.event_name == 'pull_request' &&
+        needs.approval-gate.outputs.approved == 'true'))
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.12", "3.13", "3.14"]
     env:
-      ANSIBLE_COLLECTIONS_CACHE_KEY: ansible-collections-${{ hashFiles('.github/collections/requirements.yml', 'galaxy.yml', '.pre-commit-config.yaml') }}
       HAS_CERTIFIED_HUB: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       ANSIBLE_GALAXY_SERVER_LIST: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'certified,galaxy' || 'galaxy' }}
       ANSIBLE_GALAXY_SERVER_CERTIFIED_URL: https://console.redhat.com/api/automation-hub/content/published/
@@ -47,11 +152,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Restore Ansible collections cache
-        uses: actions/cache/restore@1bd1e96a41e5c6a8698213da4c832badfcbfdfdd # v4.2.0
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: collections_cache
         with:
           path: ~/.ansible/collections
-          key: ${{ env.ANSIBLE_COLLECTIONS_CACHE_KEY }}
+          key: ansible-collections-${{ hashFiles('.github/collections/requirements.yml', 'galaxy.yml', '.pre-commit-config.yaml') }}
           restore-keys: |
             ansible-collections-
 
@@ -88,10 +193,10 @@ jobs:
           matrix.python-version == '3.12' &&
           (github.event_name == 'push' || github.event_name == 'schedule') &&
           steps.install_collections.outcome == 'success'
-        uses: actions/cache/save@1bd1e96a41e5c6a8698213da4c832badfcbfdfdd # v4.2.0
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/.ansible/collections
-          key: ${{ env.ANSIBLE_COLLECTIONS_CACHE_KEY }}
+          key: ansible-collections-${{ hashFiles('.github/collections/requirements.yml', 'galaxy.yml', '.pre-commit-config.yaml') }}
 
   # Single check name for branch protection (matrix jobs report as pre-commit-tests (3.x)).
   pre-commit:

--- a/changelogs/fragments/ci-approve-label-github-script.yml
+++ b/changelogs/fragments/ci-approve-label-github-script.yml
@@ -1,4 +1,10 @@
 ---
 bugfixes:
-  - apply the ci-approved label via actions/github-script in the trusted approval
-    workflow instead of gh pr edit, which fails without a git checkout
+  - compute the Ansible collections cache key in cache steps instead of job env,
+    because hashFiles is not available in jobs.<job_id>.env
+  - wait in the pull request approval-gate job until pre-commit approval completes
+    before running tests, instead of re-running workflows via workflow_run
+  - gate pull_request test execution on a successful pre-commit approval workflow run
+    for the current head SHA
+  - remove ci-approved labels now that approval completion is the gate signal
+  - fix invalid actions/cache commit pin that prevented cache restore and save

--- a/changelogs/fragments/controller_export_diff_retry_docs.yml
+++ b/changelogs/fragments/controller_export_diff_retry_docs.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Document max_retries and retry_backoff_factor on controller_export_diff so validate-modules
+    matches ansible.controller 4.8.3 AUTH_ARGSPEC.

--- a/changelogs/fragments/tox-skip-missing-interpreters.yml
+++ b/changelogs/fragments/tox-skip-missing-interpreters.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "tox-ansible - set skip_missing_interpreters so CI matrix jobs only run sanity envs for the installed Python"

--- a/plugins/modules/controller_export_diff.py
+++ b/plugins/modules/controller_export_diff.py
@@ -153,6 +153,22 @@ options:
       type: float
       aliases: [ aap_request_timeout ]
       version_added: "2.6.0"
+    max_retries:
+      description:
+      - Specify the max retries to be used with some connection issues.
+      - Defaults to 5.
+      - If value not set, will try environment variable C(AAP_MAX_RETRIES) and then config files.
+      - This option requires a recent ansible.controller collection that exposes retry options.
+      type: int
+      aliases: [ aap_max_retries ]
+    retry_backoff_factor:
+      description:
+      - Backoff factor used when retrying connections.
+      - Defaults to 2.
+      - If value not set, will try environment variable C(AAP_RETRY_BACKOFF_FACTOR) and then config files.
+      - This option requires a recent ansible.controller collection that exposes retry options.
+      type: int
+      aliases: [ aap_retry_backoff_factor ]
     controller_config_file:
       description:
       - Path to the controller config file.

--- a/tox-ansible.ini
+++ b/tox-ansible.ini
@@ -1,3 +1,7 @@
+[tox]
+# Each CI matrix job installs only one Python; skip envs for missing interpreters.
+skip_missing_interpreters = true
+
 [ansible]
 skip =
     py3.7


### PR DESCRIPTION
## Summary

- Add an `approval-gate` job to `pre-commit and sanity tests` that polls until `pre-commit approval` completes successfully for the PR head SHA, then runs the test matrix in the same workflow run.
- Remove `ci-approved` label handling from the trusted approval workflow; workflow completion is the gate signal (labels added via `GITHUB_TOKEN` cannot trigger `pull_request` workflows anyway).
- Fix invalid `hashFiles` usage in job `env` by moving the Ansible collections cache key into cache steps.
- Fix the invalid `actions/cache` v4.2.0 commit pin.

## Security model

| Workflow | Trigger | Role |
|----------|---------|------|
| `pre-commit approval` | `pull_request_target` | Trusted approval gate; no PR code execution |
| `pre-commit and sanity tests` | `pull_request` / `push` / `schedule` | Sandboxed test execution; waits for approval on PRs |

## Test plan

- [ ] Open or sync a trusted collaborator PR (no `.github` changes) and confirm tests run after `auto-approve` completes.
- [ ] Open or sync a PR that modifies `.github/**` and confirm `manual-approval` must complete before tests start.
- [ ] Confirm `pre-commit-tests (3.12/3.13/3.14)` and `pre-commit` checks appear on the PR.
- [ ] Confirm push to `devel` and scheduled runs are unaffected.
- [ ] Confirm branch protection can require `pre-commit-tests` / `pre-commit` checks.


Made with [Cursor](https://cursor.com)