### PR TITLE
fix(filetree_create): org task-name warning and empty env_variables stub

### DIFF
--- a/changelogs/fragments/filetree-org-name-and-env-stub.yml
+++ b/changelogs/fragments/filetree-org-name-and-env-stub.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - filetree_create - Avoid ansible-core task-name templating warnings by not referencing the loop variable in the organizations output-directory task name (path remains in the loop label).
+  - filetree_create - Stop writing an empty mapping (``{}``) into ``env_variables.yml`` when no ``vaulted_*`` placeholders are found, and exclude that stub from ``yaml_format`` so comments are preserved.

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -608,8 +608,10 @@ ansible-playbook playbooks/import_filetree.yml \
 - Approval nodes are described inline in the WFJT YAML; they do not create separate Controller objects to export.
 - Nested workflow nodes (`unified_job_type: workflow_job`) are exported as Workflow Job Template
   objects (by name) without recursively cascading their related set (avoids cycles). Re-run related
-  export on those nested workflows if you need their full dependency tree.
+  export on those nested workflows if you need their full dependency tree (and their `env_variables.yml` keys).
 - Job nodes (`unified_job_type: job`) still cascade each Job Template with its full related set.
+- If `env_variables.yml` has no keys, the export had no `vaulted_*` placeholders (for example a WFJT whose
+  nodes are only nested workflows). Export those nested workflows (or a JT) with related objects enabled.
 - If `yaml_format` warns about missing PyYAML, the export files are still valid; install PyYAML for
   the configured `interpreter_python`, or use `--skip-tags yaml_format`.
 - See also playbooks: `export_job_template_related.yml`, `export_workflow_job_template_related.yml`, `import_filetree.yml`.

--- a/roles/filetree_create/tasks/controller_organizations.yml
+++ b/roles/filetree_create/tasks/controller_organizations.yml
@@ -57,7 +57,7 @@
 - name: "Block for to generate the filetree_create normal output"
   when: flatten_output is not defined or not (flatten_output | bool)
   block:
-    - name: "Create the output directory for organizations: {{ output_path + '/' + current_organization_dir.name }}"
+    - name: "Create the output directory for organizations"
       ansible.builtin.file:
         path: "{{ __path }}"
         state: directory

--- a/roles/filetree_create/tasks/main.yml
+++ b/roles/filetree_create/tasks/main.yml
@@ -64,6 +64,9 @@
         patterns:
           - '*.yaml'
           - '*.yml'
+        excludes:
+          # Keep stub comments / CHANGE_ME values; format_yaml collapses an empty stub to "{}".
+          - 'env_variables.yml'
       register: _generated_files
 
     - name: "Format generated files (indent, truthy, document markers, trailing whitespace)"

--- a/roles/filetree_create/templates/env_variables.j2
+++ b/roles/filetree_create/templates/env_variables.j2
@@ -5,7 +5,8 @@
 #
 {% if env_variable_keys | length == 0 %}
 # No {{ secrets_as_variables_prefix }}_* placeholders were found in the export.
-{}
+# If you expected keys here, confirm secrets_as_variables / env_fields_as_variables
+# are enabled and that related JT/project objects (not only nested WFJT shells) were exported.
 {% else %}
 {% for key in env_variable_keys | sort %}
 {{ key }}: {{ env_variables_stub_placeholder }}


### PR DESCRIPTION
## Summary
- Fix ansible-core warnings on `Create the output directory for organizations` where the task name referenced `current_organization_dir` before the loop variable was bound.
- When no `vaulted_*` placeholders are found, write a comment-only `env_variables.yml` instead of `--- {}`, and exclude that stub from `yaml_format` so comments are not collapsed.

## Test plan
- [ ] Export a JT with related objects and confirm no `current_organization_dir` template warning
- [ ] Export a WFJT whose nodes are only nested workflows (e.g. `MainWF`) and confirm `env_variables.yml` is comment-only (not `{}`) when no placeholders exist
- [ ] Export a JT that emits `vaulted_*` fields and confirm `env_variables.yml` still lists `CHANGE_ME` keys
- [ ] pre-commit / ansible-lint green


Made with [Cursor](https://cursor.com)