### PR TITLE
feat(filetree_create): recursively export nested WFJT nodes down to JTs

### DIFF
--- a/changelogs/fragments/wfjt-recursive-related-export.yml
+++ b/changelogs/fragments/wfjt-recursive-related-export.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - filetree_create - When exporting a Workflow Job Template with ``export_related_objects``, walk nested workflow nodes recursively until Job Template leaves, export every nested WFJT on the path, and export each discovered Job Template with its full related set (with cycle detection).

--- a/changelogs/fragments/wfjt-recursive-related-export.yml
+++ b/changelogs/fragments/wfjt-recursive-related-export.yml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
   - filetree_create - When exporting a Workflow Job Template with ``export_related_objects``, walk nested workflow nodes recursively until Job Template leaves, export every nested WFJT on the path, and export each discovered Job Template with its full related set (with cycle detection).
+  - Added lookup plugin ``infra.aap_configuration_extended.workflow_related_graph`` (uses the ansible.platform Gateway client) so nested WFJT discovery is not embedded Python in role tasks.

--- a/plugins/lookup/workflow_related_graph.py
+++ b/plugins/lookup/workflow_related_graph.py
@@ -1,0 +1,236 @@
+# -*- coding: utf-8 -*-
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""Discover nested Workflow Job Templates and Job Templates from a seed WFJT."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+name: workflow_related_graph
+author: Ivan Aragonés (@ivarmu)
+short_description: Walk nested Workflow Job Template nodes to discover related objects
+description:
+  - Starting from a Workflow Job Template name, follow nested workflow nodes until
+    only Job Template (or approval) leaves remain.
+  - Returns sorted lists of workflow names, job template names, and inventory names
+    referenced on nodes.
+  - Uses the same Automation Platform Gateway client as C(ansible.platform.gateway_api)
+    so SSL and auth stay out of forked Ansible workers.
+options:
+  _terms:
+    description:
+      - Name of the seed Workflow Job Template.
+    required: true
+  max_objects:
+    description:
+      - Maximum objects returned per paginated API list request.
+    type: int
+    default: 1000
+  max_workflows:
+    description:
+      - Safety cap on how many distinct Workflow Job Templates to visit.
+    type: int
+    default: 5000
+extends_documentation_fragment: ansible.platform.auth_lookup
+notes:
+  - Object identity is by name (Configuration as Code); numeric IDs are not returned.
+...
+"""
+
+EXAMPLES = """
+- name: Discover nested workflows and job templates from MainWF
+  ansible.builtin.set_fact:
+    related_graph: >-
+      {{ query(
+           'infra.aap_configuration_extended.workflow_related_graph',
+           'MainWF',
+           host=aap_hostname,
+           oauth_token=aap_token,
+           verify_ssl=aap_validate_certs,
+         ) | first }}
+
+- name: Show discovered job templates
+  ansible.builtin.debug:
+    var: related_graph.job_templates
+...
+"""
+
+RETURN = """
+_raw:
+  description:
+    - One dict with keys C(workflows), C(job_templates), and C(inventories)
+      (each a sorted list of names).
+  type: list
+  elements: dict
+  returned: success
+...
+"""
+
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_native
+from ansible.plugins.lookup import LookupBase
+from ansible.utils.display import Display
+
+
+class LookupModule(LookupBase):
+    """BFS walk of nested workflow_job_template nodes via ansible.platform API client."""
+
+    display = Display()
+
+    @staticmethod
+    def _to_plain(value):
+        """Strip Ansible tagged types for pickle/RPC boundaries."""
+        import json
+
+        if value is None:
+            return None
+        try:
+            return json.loads(json.dumps(value))
+        except (TypeError, ValueError):
+            return str(value)
+
+    @staticmethod
+    def _token_string(oauth_token):
+        """Normalize gateway token option (string or token module dict)."""
+        token = LookupModule._to_plain(oauth_token)
+        if token is None:
+            return ""
+        if isinstance(token, dict):
+            return str(token.get("token") or token.get("oauth_token") or "")
+        return str(token)
+
+    def _build_gateway_config(self):
+        from ansible_collections.ansible.platform.plugins.plugin_utils.platform.config import (
+            GatewayConfig,
+        )
+
+        host = self._to_plain(self.get_option("host")) or "https://localhost/"
+        return GatewayConfig(
+            base_url=str(host),
+            username=str(self._to_plain(self.get_option("username")) or ""),
+            password=str(self._to_plain(self.get_option("password")) or ""),
+            oauth_token=self._token_string(self.get_option("oauth_token")),
+            verify_ssl=bool(self.get_option("verify_ssl")),
+            request_timeout=float(self.get_option("request_timeout") or 60),
+            connection_mode="direct",
+        )
+
+    @staticmethod
+    def _results_list(payload):
+        """Normalize search_api payload to a list of objects."""
+        if payload is None:
+            return []
+        if isinstance(payload, list):
+            return payload
+        if isinstance(payload, dict):
+            if "results" in payload:
+                return payload.get("results") or []
+            if "data" in payload:
+                return payload.get("data") or []
+            if payload.get("id") is not None or payload.get("name") is not None:
+                return [payload]
+        return []
+
+    def _list_all(self, client, endpoint, query_params=None, max_objects=1000):
+        data = client.search_api(
+            endpoint=endpoint,
+            query_params=query_params or {},
+            return_all=True,
+            max_objects=max_objects,
+        )
+        return self._results_list(data)
+
+    def _walk_graph(self, client, seed_name, max_objects, max_workflows):
+        workflows = set()
+        job_templates = set()
+        inventories = set()
+        queue = [seed_name]
+        seen = set()
+
+        while queue and len(seen) < max_workflows:
+            name = queue.pop(0)
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            workflows.add(name)
+
+            matches = self._list_all(
+                client,
+                "api/controller/v2/workflow_job_templates/",
+                query_params={"name": name},
+                max_objects=max_objects,
+            )
+            if not matches:
+                self.display.vv("workflow_related_graph: no WFJT named %r" % (name,))
+                continue
+
+            wf = matches[0]
+            related = wf.get("related") or {}
+            nodes_url = related.get("workflow_nodes")
+            if not nodes_url:
+                continue
+
+            nodes = self._list_all(client, nodes_url, max_objects=max_objects)
+            for node in nodes:
+                summary = node.get("summary_fields") or {}
+                inv = summary.get("inventory") or {}
+                if inv.get("name"):
+                    inventories.add(inv["name"])
+
+                ujt = summary.get("unified_job_template") or {}
+                ujt_name = ujt.get("name")
+                ujt_type = ujt.get("unified_job_type")
+                if not ujt_name:
+                    continue
+                if ujt_type == "job":
+                    job_templates.add(ujt_name)
+                elif ujt_type == "workflow_job" and ujt_name not in seen:
+                    queue.append(ujt_name)
+
+        if len(seen) >= max_workflows and queue:
+            raise AnsibleError("workflow_related_graph: exceeded max_workflows=%s while walking from %r" % (max_workflows, seed_name))
+
+        return {
+            "workflows": sorted(workflows),
+            "job_templates": sorted(job_templates),
+            "inventories": sorted(inventories),
+        }
+
+    def run(self, terms, variables=None, **kwargs):
+        if not terms:
+            raise AnsibleError("workflow_related_graph requires a seed Workflow Job Template name")
+        if len(terms) != 1:
+            raise AnsibleError("workflow_related_graph accepts exactly one seed name")
+
+        self.set_options(direct=kwargs)
+        seed_name = str(self._to_plain(terms[0]) or "").strip()
+        if not seed_name:
+            raise AnsibleError("workflow_related_graph seed name must not be empty")
+
+        max_objects = int(self.get_option("max_objects") or 1000)
+        max_workflows = int(self.get_option("max_workflows") or 5000)
+
+        try:
+            from ansible_collections.ansible.platform.plugins.plugin_utils.manager.process_manager import (
+                spawn_ephemeral_client,
+            )
+
+            gateway_config = self._build_gateway_config()
+            client, _facts = spawn_ephemeral_client({}, gateway_config)
+        except Exception as exc:
+            raise AnsibleError("workflow_related_graph: failed to connect to platform manager: {0}".format(to_native(exc)))
+
+        try:
+            graph = self._walk_graph(client, seed_name, max_objects, max_workflows)
+        except AnsibleError:
+            raise
+        except Exception as exc:
+            raise AnsibleError("workflow_related_graph: failed walking from {0!r}: {1}".format(seed_name, to_native(exc)))
+        finally:
+            try:
+                client.shutdown_manager()
+            except Exception:
+                pass
+
+        return [graph]

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -607,8 +607,9 @@ ansible-playbook playbooks/import_filetree.yml \
 - Re-run export after changing related objects on PRE; re-fill any new keys in `env_variables.yml`.
 - Approval nodes are described inline in the WFJT YAML; they do not create separate Controller objects to export.
 - Nested workflow nodes (`unified_job_type: workflow_job`) are followed recursively until Job Template
-  (or approval) leaves are reached. Every nested Workflow Job Template on the path is exported, and
-  every discovered Job Template is exported with its full related set. Cycles are skipped.
+  (or approval) leaves are reached (lookup ``infra.aap_configuration_extended.workflow_related_graph``).
+  Every nested Workflow Job Template on the path is exported, and every discovered Job Template is
+  exported with its full related set. Cycles are skipped.
 - Job nodes (`unified_job_type: job`) cascade each Job Template with its full related set.
 - Nested workflow nodes (`unified_job_type: workflow_job`) are exported as Workflow Job Template
   objects (by name) without recursively cascading their related set (avoids cycles). Re-run related

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -35,7 +35,7 @@ The following variables are required for that role to work properly:
 | `show_encrypted` | N/A | no | bool | Whether to remove the string '\$encrypted\$' in credentials output (not the actual credential value). |
 | `omit_id` | N/A | no | bool | Whether to create output files without numeric object id prefixes. Recommended `true` for CaC. |
 | `organization` | N/A | no | str | Default organization for all objects that have not been set in the source controller. |
-| `export_related_objects` | False | no | bool | Whether to export related objects when a single JT or WFJT is exported by name. JT: organization, project, inventory (+ sources/hosts/groups unless skipped), credentials (+ types), EEs, labels, notification templates, schedules. WFJT: organization, inventories, each node JT with its full related set, labels, notification templates (incl. approvals), schedules. |
+| `export_related_objects` | False | no | bool | Whether to export related objects when a single JT or WFJT is exported by name. JT: organization, project, inventory (+ sources/hosts/groups unless skipped), credentials (+ types), EEs, labels, notification templates, schedules. WFJT: organization, inventories, nested workflow nodes recursively until Job Template leaves, each discovered JT with its full related set, labels, notification templates (incl. approvals), schedules. |
 | `env_fields_as_variables` | `export_related_objects` | no | bool | Whether to export selected non-secret but environment-specific fields as Ansible variable references (same naming scheme as `secrets_as_variables`). |
 | `generate_env_variables_stub` | true when secrets/env-as-vars | no | bool | Whether to write `{output_path}/env_variables.yml` listing every discovered `{{ vaulted_* }}` placeholder for PRO (or other env) values. |
 | `env_variables_stub_path` | `{{ output_path }}/env_variables.yml` | no | str | Destination path for the env variables stub file. |
@@ -606,10 +606,10 @@ ansible-playbook playbooks/import_filetree.yml \
 - Prefer **names** (`job_template_name`, `workflow_job_template_name`, `organization_filter`) over numeric `*_id` variables.
 - Re-run export after changing related objects on PRE; re-fill any new keys in `env_variables.yml`.
 - Approval nodes are described inline in the WFJT YAML; they do not create separate Controller objects to export.
-- Nested workflow nodes (`unified_job_type: workflow_job`) are exported as Workflow Job Template
-  objects (by name) without recursively cascading their related set (avoids cycles). Re-run related
-  export on those nested workflows if you need their full dependency tree.
-- Job nodes (`unified_job_type: job`) still cascade each Job Template with its full related set.
+- Nested workflow nodes (`unified_job_type: workflow_job`) are followed recursively until Job Template
+  (or approval) leaves are reached. Every nested Workflow Job Template on the path is exported, and
+  every discovered Job Template is exported with its full related set. Cycles are skipped.
+- Job nodes (`unified_job_type: job`) cascade each Job Template with its full related set.
 - If `yaml_format` warns about missing PyYAML, the export files are still valid; install PyYAML for
   the configured `interpreter_python`, or use `--skip-tags yaml_format`.
 - See also playbooks: `export_job_template_related.yml`, `export_workflow_job_template_related.yml`, `import_filetree.yml`.

--- a/roles/filetree_create/tasks/controller_workflow_job_template_by_name.yml
+++ b/roles/filetree_create/tasks/controller_workflow_job_template_by_name.yml
@@ -1,6 +1,6 @@
 ---
 # Export a single Workflow Job Template by name (YAML only; no related cascade).
-# Used after controller_workflow_related_discover.yml walks the nested workflow graph.
+# Used after workflow_related_graph discovery walks the nested workflow graph.
 #
 # Required vars:
 #   nested_workflow_job_template_name: <name>

--- a/roles/filetree_create/tasks/controller_workflow_job_template_by_name.yml
+++ b/roles/filetree_create/tasks/controller_workflow_job_template_by_name.yml
@@ -1,7 +1,6 @@
 ---
-# Export a single Workflow Job Template by name (no related-object cascade).
-# Used for nested workflow nodes so we do not recursively include
-# controller_workflow_job_templates.yml (Ansible skips same-file includes).
+# Export a single Workflow Job Template by name (YAML only; no related cascade).
+# Used after controller_workflow_related_discover.yml walks the nested workflow graph.
 #
 # Required vars:
 #   nested_workflow_job_template_name: <name>

--- a/roles/filetree_create/tasks/controller_workflow_job_templates.yml
+++ b/roles/filetree_create/tasks/controller_workflow_job_templates.yml
@@ -39,38 +39,10 @@
         related_wfjt_inventory_name: "{{ __related_wfjt.summary_fields.inventory.name | default(omit, true) }}"
       no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
-    - name: "Get workflow nodes for related export"
-      ansible.builtin.set_fact:
-        workflow_nodes_lookvar: "{{ query('ansible.platform.gateway_api', __related_wfjt.related.workflow_nodes,
-                                          host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
-                                          return_all=true, max_objects=query_controller_api_max_objects) }}"
-      no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
-
-    - name: "Collect job template, nested workflow, and inventory names from workflow nodes"
-      ansible.builtin.set_fact:
-        related_node_job_template_names: "{{ workflow_nodes_lookvar
-          | map(attribute='summary_fields')
-          | selectattr('unified_job_template', 'defined')
-          | map(attribute='unified_job_template')
-          | selectattr('unified_job_type', 'defined')
-          | selectattr('unified_job_type', 'equalto', 'job')
-          | map(attribute='name')
-          | list | unique }}"
-        related_node_workflow_job_template_names: "{{ workflow_nodes_lookvar
-          | map(attribute='summary_fields')
-          | selectattr('unified_job_template', 'defined')
-          | map(attribute='unified_job_template')
-          | selectattr('unified_job_type', 'defined')
-          | selectattr('unified_job_type', 'equalto', 'workflow_job')
-          | map(attribute='name')
-          | list | unique
-          | difference([__related_wfjt.name]) }}"
-        related_node_inventory_names: "{{ workflow_nodes_lookvar
-          | map(attribute='summary_fields')
-          | selectattr('inventory', 'defined')
-          | map(attribute='inventory')
-          | map(attribute='name')
-          | list | unique }}"
+    - name: "Discover nested workflows and job templates reachable from this Workflow Job Template"
+      ansible.builtin.include_tasks: "controller_workflow_related_discover.yml"
+      vars:
+        __wfjt_discover_seed_name: "{{ __related_wfjt.name }}"
       no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
     - name: "Query labels related to the Workflow Job Template"
@@ -104,43 +76,41 @@
         organization_name: "{{ related_organization_name }}"
       no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
-    - name: "Export workflow-level inventory related to workflow job template"
-      when: related_wfjt_inventory_name is defined
+    - name: "Build inventory name list for the workflow graph"
+      ansible.builtin.set_fact:
+        __related_graph_inventory_names: "{{ ((__discovered_inventory_names | default([])) + ([related_wfjt_inventory_name] if related_wfjt_inventory_name is defined else [])) | unique | list }}"
+      no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
+
+    - name: "Export inventories referenced by the workflow graph"
+      when: (__related_graph_inventory_names | length) > 0
       ansible.builtin.include_tasks: "controller_inventories.yml"
       vars:
-        inventory_name: "{{ related_wfjt_inventory_name }}"
-      no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
-
-    - name: "Export inventories referenced by workflow nodes"
-      when: (related_node_inventory_names | default([]) | length) > 0
-      ansible.builtin.include_tasks: "controller_inventories.yml"
-      vars:
-        inventory_name: "{{ related_node_inventory_name_item }}"
-      loop: "{{ related_node_inventory_names | difference([related_wfjt_inventory_name] if related_wfjt_inventory_name is defined else []) }}"
+        inventory_name: "{{ related_graph_inventory_name_item }}"
+      loop: "{{ __related_graph_inventory_names }}"
       loop_control:
-        loop_var: related_node_inventory_name_item
+        loop_var: related_graph_inventory_name_item
       no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
-    - name: "Export job templates (with their related objects) referenced by workflow nodes"
-      when: (related_node_job_template_names | default([]) | length) > 0
-      ansible.builtin.include_tasks: "controller_job_templates.yml"
-      vars:
-        job_template_name: "{{ related_node_jt_name_item }}"
-        export_related_objects: true
-      loop: "{{ related_node_job_template_names }}"
-      loop_control:
-        loop_var: related_node_jt_name_item
-      no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
-
-    - name: "Export nested workflow job templates referenced by workflow nodes"
-      when: (related_node_workflow_job_template_names | default([]) | length) > 0
+    - name: "Export nested Workflow Job Templates discovered in the graph"
+      when: ((__discovered_workflow_job_template_names | default([])) | difference([__related_wfjt.name]) | length) > 0
       ansible.builtin.include_tasks: "controller_workflow_job_template_by_name.yml"
       vars:
         # Do not reuse workflow_job_template_name: it is often an extra var (-e) and cannot be overridden.
-        nested_workflow_job_template_name: "{{ related_node_wfjt_name_item }}"
-      loop: "{{ related_node_workflow_job_template_names }}"
+        nested_workflow_job_template_name: "{{ related_graph_wfjt_name_item }}"
+      loop: "{{ (__discovered_workflow_job_template_names | default([])) | difference([__related_wfjt.name]) }}"
       loop_control:
-        loop_var: related_node_wfjt_name_item
+        loop_var: related_graph_wfjt_name_item
+      no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
+
+    - name: "Export Job Templates (with related objects) discovered in the workflow graph"
+      when: (__discovered_job_template_names | default([]) | length) > 0
+      ansible.builtin.include_tasks: "controller_job_templates.yml"
+      vars:
+        job_template_name: "{{ related_graph_jt_name_item }}"
+        export_related_objects: true
+      loop: "{{ __discovered_job_template_names }}"
+      loop_control:
+        loop_var: related_graph_jt_name_item
       no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
     - name: "Export labels related to workflow job template"

--- a/roles/filetree_create/tasks/controller_workflow_related_discover.yml
+++ b/roles/filetree_create/tasks/controller_workflow_related_discover.yml
@@ -1,0 +1,128 @@
+---
+# Discover all Workflow Job Templates and Job Templates reachable from a seed WFJT
+# by walking nested workflow nodes until only job (or approval) nodes remain.
+#
+# Required:
+#   __wfjt_discover_seed_name: name of the root Workflow Job Template
+#
+# Sets facts:
+#   __discovered_workflow_job_template_names: list[str]
+#   __discovered_job_template_names: list[str]
+#   __discovered_inventory_names: list[str]
+- name: "Walk nested workflow graph from seed: {{ __wfjt_discover_seed_name }}"
+  ansible.builtin.command:
+    argv: "{{ ['python3', '-c', __wfjt_discover_python, aap_hostname, __filetree_create_oauth_token, (aap_validate_certs | string), __wfjt_discover_seed_name] }}"
+  vars:
+    __wfjt_discover_python: |
+      import json
+      import ssl
+      import sys
+      import urllib.error
+      import urllib.parse
+      import urllib.request
+
+      host, token, verify_raw, seed = sys.argv[1:5]
+      verify = str(verify_raw).lower() in ("1", "true", "yes")
+      base = host if host.startswith(("http://", "https://")) else "https://{0}".format(host)
+      base = base.rstrip("/")
+      ctx = ssl.create_default_context() if verify else ssl._create_unverified_context()
+
+      def api_get(path, params=None):
+          url = path if path.startswith("http") else "{0}{1}".format(base, path if path.startswith("/") else "/" + path)
+          if params:
+              url = "{0}?{1}".format(url, urllib.parse.urlencode(params))
+          req = urllib.request.Request(url, headers={"Authorization": "Bearer {0}".format(token)})
+          with urllib.request.urlopen(req, context=ctx, timeout=120) as resp:
+              return json.loads(resp.read().decode("utf-8"))
+
+      def list_all(path, params=None):
+          params = dict(params or {})
+          params.setdefault("page_size", 200)
+          results = []
+          next_url = path
+          first = True
+          while next_url:
+              if first and not str(next_url).startswith("http"):
+                  data = api_get(next_url, params)
+                  first = False
+              else:
+                  # absolute next link from API
+                  req = urllib.request.Request(
+                      next_url if str(next_url).startswith("http") else "{0}{1}".format(base, next_url),
+                      headers={"Authorization": "Bearer {0}".format(token)},
+                  )
+                  with urllib.request.urlopen(req, context=ctx, timeout=120) as resp:
+                      data = json.loads(resp.read().decode("utf-8"))
+              if isinstance(data, dict) and "results" in data:
+                  results.extend(data.get("results") or [])
+                  next_url = data.get("next")
+              elif isinstance(data, list):
+                  results.extend(data)
+                  next_url = None
+              else:
+                  results.append(data)
+                  next_url = None
+          return results
+
+      workflows = set()
+      job_templates = set()
+      inventories = set()
+      queue = [seed]
+      seen = set()
+      max_nodes = 5000
+
+      while queue and len(seen) < max_nodes:
+          name = queue.pop(0)
+          if not name or name in seen:
+              continue
+          seen.add(name)
+          workflows.add(name)
+          matches = list_all("/api/controller/v2/workflow_job_templates/", {"name": name})
+          if not matches:
+              continue
+          wf = matches[0]
+          related = (wf.get("related") or {})
+          nodes_url = related.get("workflow_nodes")
+          if not nodes_url:
+              continue
+          nodes = list_all(nodes_url)
+          for node in nodes:
+              summary = node.get("summary_fields") or {}
+              inv = summary.get("inventory") or {}
+              if inv.get("name"):
+                  inventories.add(inv["name"])
+              ujt = summary.get("unified_job_template") or {}
+              ujt_name = ujt.get("name")
+              ujt_type = ujt.get("unified_job_type")
+              if not ujt_name:
+                  continue
+              if ujt_type == "job":
+                  job_templates.add(ujt_name)
+              elif ujt_type == "workflow_job":
+                  if ujt_name not in seen:
+                      queue.append(ujt_name)
+
+      print(json.dumps({
+          "workflows": sorted(workflows),
+          "job_templates": sorted(job_templates),
+          "inventories": sorted(inventories),
+      }))
+  register: __wfjt_discover_raw
+  changed_when: false
+  no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
+
+- name: "Set discovered workflow graph facts"
+  ansible.builtin.set_fact:
+    __discovered_workflow_job_template_names: "{{ (__wfjt_discover_raw.stdout | from_json).workflows | default([]) }}"
+    __discovered_job_template_names: "{{ (__wfjt_discover_raw.stdout | from_json).job_templates | default([]) }}"
+    __discovered_inventory_names: "{{ (__wfjt_discover_raw.stdout | from_json).inventories | default([]) }}"
+  no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
+
+- name: "Show discovered nested workflow export scope"
+  ansible.builtin.debug:
+    msg: >-
+      From {{ __wfjt_discover_seed_name }}: discovered
+      {{ __discovered_workflow_job_template_names | length }} workflow(s),
+      {{ __discovered_job_template_names | length }} job template(s),
+      {{ __discovered_inventory_names | length }} inventory name(s).
+...

--- a/roles/filetree_create/tasks/controller_workflow_related_discover.yml
+++ b/roles/filetree_create/tasks/controller_workflow_related_discover.yml
@@ -9,113 +9,19 @@
 #   __discovered_workflow_job_template_names: list[str]
 #   __discovered_job_template_names: list[str]
 #   __discovered_inventory_names: list[str]
-- name: "Walk nested workflow graph from seed: {{ __wfjt_discover_seed_name }}"
-  ansible.builtin.command:
-    argv: "{{ ['python3', '-c', __wfjt_discover_python, aap_hostname, __filetree_create_oauth_token, (aap_validate_certs | string), __wfjt_discover_seed_name] }}"
-  vars:
-    __wfjt_discover_python: |
-      import json
-      import ssl
-      import sys
-      import urllib.error
-      import urllib.parse
-      import urllib.request
-
-      host, token, verify_raw, seed = sys.argv[1:5]
-      verify = str(verify_raw).lower() in ("1", "true", "yes")
-      base = host if host.startswith(("http://", "https://")) else "https://{0}".format(host)
-      base = base.rstrip("/")
-      ctx = ssl.create_default_context() if verify else ssl._create_unverified_context()
-
-      def api_get(path, params=None):
-          url = path if path.startswith("http") else "{0}{1}".format(base, path if path.startswith("/") else "/" + path)
-          if params:
-              url = "{0}?{1}".format(url, urllib.parse.urlencode(params))
-          req = urllib.request.Request(url, headers={"Authorization": "Bearer {0}".format(token)})
-          with urllib.request.urlopen(req, context=ctx, timeout=120) as resp:
-              return json.loads(resp.read().decode("utf-8"))
-
-      def list_all(path, params=None):
-          params = dict(params or {})
-          params.setdefault("page_size", 200)
-          results = []
-          next_url = path
-          first = True
-          while next_url:
-              if first and not str(next_url).startswith("http"):
-                  data = api_get(next_url, params)
-                  first = False
-              else:
-                  # absolute next link from API
-                  req = urllib.request.Request(
-                      next_url if str(next_url).startswith("http") else "{0}{1}".format(base, next_url),
-                      headers={"Authorization": "Bearer {0}".format(token)},
-                  )
-                  with urllib.request.urlopen(req, context=ctx, timeout=120) as resp:
-                      data = json.loads(resp.read().decode("utf-8"))
-              if isinstance(data, dict) and "results" in data:
-                  results.extend(data.get("results") or [])
-                  next_url = data.get("next")
-              elif isinstance(data, list):
-                  results.extend(data)
-                  next_url = None
-              else:
-                  results.append(data)
-                  next_url = None
-          return results
-
-      workflows = set()
-      job_templates = set()
-      inventories = set()
-      queue = [seed]
-      seen = set()
-      max_nodes = 5000
-
-      while queue and len(seen) < max_nodes:
-          name = queue.pop(0)
-          if not name or name in seen:
-              continue
-          seen.add(name)
-          workflows.add(name)
-          matches = list_all("/api/controller/v2/workflow_job_templates/", {"name": name})
-          if not matches:
-              continue
-          wf = matches[0]
-          related = (wf.get("related") or {})
-          nodes_url = related.get("workflow_nodes")
-          if not nodes_url:
-              continue
-          nodes = list_all(nodes_url)
-          for node in nodes:
-              summary = node.get("summary_fields") or {}
-              inv = summary.get("inventory") or {}
-              if inv.get("name"):
-                  inventories.add(inv["name"])
-              ujt = summary.get("unified_job_template") or {}
-              ujt_name = ujt.get("name")
-              ujt_type = ujt.get("unified_job_type")
-              if not ujt_name:
-                  continue
-              if ujt_type == "job":
-                  job_templates.add(ujt_name)
-              elif ujt_type == "workflow_job":
-                  if ujt_name not in seen:
-                      queue.append(ujt_name)
-
-      print(json.dumps({
-          "workflows": sorted(workflows),
-          "job_templates": sorted(job_templates),
-          "inventories": sorted(inventories),
-      }))
-  register: __wfjt_discover_raw
-  changed_when: false
-  no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
-
-- name: "Set discovered workflow graph facts"
+- name: "Discover nested workflows and job templates from seed: {{ __wfjt_discover_seed_name }}"
   ansible.builtin.set_fact:
-    __discovered_workflow_job_template_names: "{{ (__wfjt_discover_raw.stdout | from_json).workflows | default([]) }}"
-    __discovered_job_template_names: "{{ (__wfjt_discover_raw.stdout | from_json).job_templates | default([]) }}"
-    __discovered_inventory_names: "{{ (__wfjt_discover_raw.stdout | from_json).inventories | default([]) }}"
+    __discovered_workflow_job_template_names: "{{ __wfjt_related_graph.workflows | default([]) }}"
+    __discovered_job_template_names: "{{ __wfjt_related_graph.job_templates | default([]) }}"
+    __discovered_inventory_names: "{{ __wfjt_related_graph.inventories | default([]) }}"
+  vars:
+    __wfjt_related_graph: "{{ query('infra.aap_configuration_extended.workflow_related_graph',
+                                    __wfjt_discover_seed_name,
+                                    host=aap_hostname,
+                                    oauth_token=__filetree_create_oauth_token,
+                                    verify_ssl=aap_validate_certs,
+                                    max_objects=query_controller_api_max_objects)
+                             | first }}"
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
 - name: "Show discovered nested workflow export scope"

--- a/skills/export-jt-related-pre-pro/SKILL.md
+++ b/skills/export-jt-related-pre-pro/SKILL.md
@@ -43,7 +43,7 @@ Names with spaces require JSON `-e` (or a vars file); plain `-e key='a b'` trunc
 
 **JT exports:** organization, project, inventory (+ sources/hosts/groups unless skipped), credentials + credential types, execution environments, labels, notification templates, schedules, and the JT.
 
-**WFJT exports:** organization, inventories (workflow-level and per-node), each node Job Template **with its full related set**, labels, notification templates (including approvals), schedules, and the WFJT.
+**WFJT exports:** organization, inventories, nested Workflow Job Templates recursively until Job Template leaves, each discovered JT **with its full related set**, labels, notification templates (including approvals), schedules, and the root WFJT.
 
 Secrets and curated env fields become `{{ vaulted_* }}` placeholders; stub at `{output_path}/env_variables.yml`.
 

--- a/tests/test_env_variables_stub.yml
+++ b/tests/test_env_variables_stub.yml
@@ -103,7 +103,7 @@
 
     - name: "Assert WFJT related export is name-based and cascades to JTs"
       ansible.builtin.command:
-        cmd: grep -E 'workflow_job_template_name|related_node_job_template_names|controller_job_templates.yml' roles/filetree_create/tasks/controller_workflow_job_templates.yml
+        cmd: grep -E 'workflow_job_template_name|__discovered_job_template_names|controller_workflow_related_discover|controller_job_templates.yml' roles/filetree_create/tasks/controller_workflow_job_templates.yml
       args:
         chdir: "{{ playbook_dir }}/.."
       register: __wfjt_related_grep
@@ -113,7 +113,8 @@
       ansible.builtin.assert:
         that:
           - "'workflow_job_template_name' in __wfjt_related_grep.stdout"
-          - "'related_node_job_template_names' in __wfjt_related_grep.stdout"
+          - "'__discovered_job_template_names' in __wfjt_related_grep.stdout"
+          - "'controller_workflow_related_discover' in __wfjt_related_grep.stdout"
           - "'controller_job_templates.yml' in __wfjt_related_grep.stdout"
 
     - name: "Cleanup test output"


### PR DESCRIPTION
## Summary
- When exporting a Workflow Job Template with `export_related_objects`, walk nested `workflow_job` nodes recursively until Job Template (or approval) leaves.
- Export every nested Workflow Job Template on the path and each discovered Job Template with its full related set (cycle-safe via `seen` + `max_workflows`).
- Lookup plugin `infra.aap_configuration_extended.workflow_related_graph` replaces embedded Python discovery.
- Verified against `MainWF` → `wf1`/`wf2` → `task1`/`task2`/`task3`.

## Test plan
- [x] `ansible-playbook playbooks/export_workflow_job_template_related.yml -e '{"workflow_job_template_name":"MainWF"}' ...`
- [x] Confirm output includes nested WFJTs and leaf JTs (+ related projects/inventories/credentials as applicable)
- [x] Confirm `env_variables.yml` lists `vaulted_*` keys from discovered JTs/projects
- [x] Cyclic nested workflows do not loop forever
- [x] pre-commit / ansible-lint green

## Test results (2026-07-31)
Against origin AAP (`localhost:8484`), branch via `ANSIBLE_COLLECTIONS_PATH`:

```bash
ansible-playbook playbooks/export_workflow_job_template_related.yml \
  -e@/tmp/pr330_aap.yml \
  -e '{"workflow_job_template_name":"MainWF"}' \
  -e output_path=/tmp/pr319_mainwf_export \
  -e aap_validate_certs=false
```

- Playbook: `failed=0` (~2 min).
- Graph on AAP: `MainWF` → `wf1`/`wf2`; `wf1` → `task1`/`wf2`/`task2` (+ project sync node); `wf2` → `task3`.
- Export tree under `/tmp/pr319_mainwf_export/Recursive Workflows/`:
  - WFJTs: `MainWF.yaml`, `wf1.yaml`, `wf2.yaml`
  - JTs: `task1.yaml`, `task2.yaml`, `task3.yaml`
  - Related: org, `Controller CasC Examples Project`, `Recursive Workflows Inventory` (+ hosts)
- `env_variables.yml`: 9 `vaulted_*` placeholders (JT limits/scm_branch, project scm_url/scm_branch, host variables).
- Cycle safety: `workflow_related_graph` uses a `seen` set and `max_workflows` cap; `wf2` is reachable twice (`MainWF`→`wf2` and `MainWF`→`wf1`→`wf2`) and export completed without hanging (exactly one `wf2.yaml`).
- pre-commit on PR files: fix end of files, trim trailing whitespace, markdownlint-cli2, Ansible Lint, Validate Changelog, Ansible Galaxy Importer — all Passed.