### PR TITLE
fix(filetree_create): honor omit_id, org filter, and missing export fields

### DIFF
--- a/changelogs/fragments/issue302-omit-id.yml
+++ b/changelogs/fragments/issue302-omit-id.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - 'filetree_create - Respect boolean ``omit_id`` value when building output filenames (``omit_id: false`` keeps numeric id prefixes; ``omit_id: true`` omits them). Fixes #302.'

--- a/changelogs/fragments/issue308-missing-export-fields.yml
+++ b/changelogs/fragments/issue308-missing-export-fields.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - 'filetree_create - Fix ``default_environment`` export for projects (was reading the wrong asset variable). Fixes #308.'
+  - 'filetree_create - Export ``enabled`` on hosts, ``overwrite_vars`` and ``execution_environment`` on inventory sources, top-level ``inventory`` on workflows, node ``credentials`` on workflow nodes, and ``organization`` on schedules. Fixes #308.'

--- a/changelogs/fragments/issue312-organization-filter.yml
+++ b/changelogs/fragments/issue312-organization-filter.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - 'filetree_create - Apply ``organization_filter`` to gateway teams, gateway authenticator maps, and controller schedules. Fixes #312.'

--- a/roles/filetree_create/tasks/controller_applications.yml
+++ b/roles/filetree_create/tasks/controller_applications.yml
@@ -73,7 +73,7 @@
         application_organization: "{{ current_applications_asset_value.summary_fields.organization.name | default(organization, true) }}"
         application_id: "{{ current_applications_asset_value.id }}"
         application_name: "{{ current_applications_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ application_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_applications }}/{{ (application_id ~ '_') if omit_id is not defined else '' }}{{ application_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ application_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_applications }}/{{ (application_id ~ '_') if not (omit_id | default(false) | bool) else '' }}{{ application_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ applications_lookvar }}"
       loop_control:
         loop_var: current_applications_asset_value

--- a/roles/filetree_create/tasks/controller_constructed_inventories.yml
+++ b/roles/filetree_create/tasks/controller_constructed_inventories.yml
@@ -82,7 +82,7 @@
         __task_name_append: "{{ filetree_create_controller_inventories }} output yaml file in {{ output_path }}"
         inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default(organization) }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_inventories }}/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if omit_id is not defined else '' }}{{ inventory_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_inventories }}/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if not (omit_id | default(false) | bool) else '' }}{{ inventory_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ constructed_inventory_lookvar }}"
       loop_control:
         loop_var: current_inventories_asset_value

--- a/roles/filetree_create/tasks/controller_credentials.yml
+++ b/roles/filetree_create/tasks/controller_credentials.yml
@@ -78,7 +78,7 @@
         credentials_organization: "{{ current_credentials_asset_value.summary_fields.organization.name | default(organization) }}"
         credentials_id: "{{ current_credentials_asset_value.id }}"
         credentials_name: "{{ current_credentials_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ credentials_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_credentials }}/{{ (credentials_id ~ '_') if omit_id is not defined else '' }}{{ credentials_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ credentials_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_credentials }}/{{ (credentials_id ~ '_') if not (omit_id | default(false) | bool) else '' }}{{ credentials_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ credentials_lookvar }}"
       loop_control:
         loop_var: current_credentials_asset_value

--- a/roles/filetree_create/tasks/controller_inventories.yml
+++ b/roles/filetree_create/tasks/controller_inventories.yml
@@ -85,7 +85,7 @@
         __task_name_append: "{{ filetree_create_controller_inventories }} output yaml file in {{ output_path }}"
         inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default(organization) }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_inventories }}/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if omit_id is not defined else '' }}{{ inventory_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_inventories }}/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if not (omit_id | default(false) | bool) else '' }}{{ inventory_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ inventory_lookvar }}"
       loop_control:
         loop_var: current_inventories_asset_value

--- a/roles/filetree_create/tasks/controller_job_templates.yml
+++ b/roles/filetree_create/tasks/controller_job_templates.yml
@@ -326,7 +326,7 @@
         job_template_organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | default(organization) }}"
         job_template_id: "{{ current_job_templates_asset_value.id }}"
         job_template_name: "{{ current_job_templates_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ job_template_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_templates }}/{{ (job_template_id ~ '_') if omit_id is not defined else '' }}{{ job_template_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ job_template_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_templates }}/{{ (job_template_id ~ '_') if not (omit_id | default(false) | bool) else '' }}{{ job_template_name | regex_replace('/', '_') }}.yaml"
         query_labels: "{{ query('ansible.platform.gateway_api', current_job_templates_asset_value.related.labels,
                          host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
                          return_all=true, max_objects=query_controller_api_max_objects) }}"

--- a/roles/filetree_create/tasks/controller_labels.yml
+++ b/roles/filetree_create/tasks/controller_labels.yml
@@ -75,7 +75,7 @@
         label_organization: "{{ current_labels_asset_value.summary_fields.organization.name | default(organization, true) }}"
         label_id: "{{ current_labels_asset_value.id }}"
         label_name: "{{ current_labels_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ label_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_labels }}/{{ (label_id ~ '_') if omit_id is not defined else '' }}{{ label_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ label_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_labels }}/{{ (label_id ~ '_') if not (omit_id | default(false) | bool) else '' }}{{ label_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ labels_lookvar }}"
       loop_control:
         loop_var: current_labels_asset_value

--- a/roles/filetree_create/tasks/controller_projects.yml
+++ b/roles/filetree_create/tasks/controller_projects.yml
@@ -85,7 +85,7 @@
         project_organization: "{{ current_projects_asset_value.summary_fields.organization.name | default(organization, true) }}"
         project_id: "{{ current_projects_asset_value.id }}"
         project_name: "{{ current_projects_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ project_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_projects }}/{{ (project_id ~ '_') if omit_id is not defined else '' }}{{ project_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ project_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_projects }}/{{ (project_id ~ '_') if not (omit_id | default(false) | bool) else '' }}{{ project_name | regex_replace('/', '_') }}.yaml"
         query_notification_error: "{{ query('ansible.platform.gateway_api', current_projects_asset_value.related.notification_templates_error,
                          host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
                          return_all=true, max_objects=query_controller_api_max_objects) }}"

--- a/roles/filetree_create/tasks/controller_schedules.yml
+++ b/roles/filetree_create/tasks/controller_schedules.yml
@@ -5,7 +5,8 @@
                                 (schedules_related_url if schedules_related_url is defined else 'api/controller/v2/schedules/'),
                                 query_params=(query_params | combine({'name': schedule_name} if schedule_name is defined and schedules_related_url is not defined else {},
                                   {'id': schedule_id} if schedule_id is defined and schedule_name is not defined and schedules_related_url is not defined else {},
-                                  {'unified_job_template': unified_job_template_id} if unified_job_template_id is defined and schedules_related_url is not defined else {})),
+                                  {'unified_job_template': unified_job_template_id} if unified_job_template_id is defined and schedules_related_url is not defined else {},
+                                  {'unified_job_template__organization': organization_id} if organization_id is defined and schedule_name is not defined and schedule_id is not defined and unified_job_template_id is not defined and schedules_related_url is not defined else {})),
                                 host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
                                 return_all=true, max_objects=query_controller_api_max_objects)
                        }}"
@@ -70,7 +71,7 @@
       vars:
         label_id: "{{ current_schedules_asset_value.id }}"
         label_name: "{{ current_schedules_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ filetree_create_controller_schedules }}/{{ (label_id ~ '_') if omit_id is not defined else '' }}{{ label_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ filetree_create_controller_schedules }}/{{ (label_id ~ '_') if not (omit_id | default(false) | bool) else '' }}{{ label_name | regex_replace('/', '_') }}.yaml"
         query_credentials: "{{ query('ansible.platform.gateway_api', current_schedules_asset_value.related.credentials,
                      host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
                      return_all=true, max_objects=query_controller_api_max_objects) if current_schedules_asset_value.related.credentials is defined else [] }}"

--- a/roles/filetree_create/tasks/controller_teams.yml
+++ b/roles/filetree_create/tasks/controller_teams.yml
@@ -73,7 +73,7 @@
         team_organization: "{{ (current_teams_asset_value.summary_fields.organization.name | default(organization, true)) | regex_replace('/', '_') }}"
         team_id: "{{ current_teams_asset_value.id }}"
         team_name: "{{ current_teams_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ team_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_teams }}/{{ (team_id ~ '_') if omit_id is not defined else '' }}{{ team_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ team_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_teams }}/{{ (team_id ~ '_') if not (omit_id | default(false) | bool) else '' }}{{ team_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ teams_lookvar }}"
       loop_control:
         loop_var: current_teams_asset_value

--- a/roles/filetree_create/tasks/controller_workflow_job_template_by_name.yml
+++ b/roles/filetree_create/tasks/controller_workflow_job_template_by_name.yml
@@ -45,7 +45,7 @@
         workflow_job_template_organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default(organization) }}"
         workflow_job_template_id: "{{ current_workflow_job_templates_asset_value.id }}"
         __nested_wfjt_file_name: "{{ current_workflow_job_templates_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ workflow_job_template_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_workflow_job_templates }}/{{ (workflow_job_template_id ~ '_') if omit_id is not defined else '' }}{{ __nested_wfjt_file_name }}.yaml"
+        __dest: "{{ output_path }}/{{ workflow_job_template_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_workflow_job_templates }}/{{ (workflow_job_template_id ~ '_') if not (omit_id | default(false) | bool) else '' }}{{ __nested_wfjt_file_name }}.yaml"
         query_labels: "{{ query('ansible.platform.gateway_api', current_workflow_job_templates_asset_value.related.labels,
                          host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
                          return_all=true, max_objects=query_controller_api_max_objects) }}"

--- a/roles/filetree_create/tasks/controller_workflow_job_templates.yml
+++ b/roles/filetree_create/tasks/controller_workflow_job_templates.yml
@@ -241,7 +241,7 @@
         workflow_job_template_organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default(organization) }}"
         workflow_job_template_id: "{{ current_workflow_job_templates_asset_value.id }}"
         workflow_job_template_name: "{{ current_workflow_job_templates_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ workflow_job_template_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_workflow_job_templates }}/{{ (workflow_job_template_id ~ '_') if omit_id is not defined else '' }}{{ workflow_job_template_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ workflow_job_template_organization | regex_replace('/', '_') }}/{{ filetree_create_controller_workflow_job_templates }}/{{ (workflow_job_template_id ~ '_') if not (omit_id | default(false) | bool) else '' }}{{ workflow_job_template_name | regex_replace('/', '_') }}.yaml"
         query_labels: "{{ query('ansible.platform.gateway_api', current_workflow_job_templates_asset_value.related.labels,
                          host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
                          return_all=true, max_objects=query_controller_api_max_objects) }}"

--- a/roles/filetree_create/tasks/eda_projects.yml
+++ b/roles/filetree_create/tasks/eda_projects.yml
@@ -87,7 +87,7 @@
             project_organization: "{{ current_projects_asset_value.organization_id | default(organization, true) }}"
             project_id: "{{ current_projects_asset_value.id }}"
             project_name: "{{ current_projects_asset_value.name | regex_replace('/', '_') }}"
-            __dest: "{{ output_path }}/{{ project_organization | regex_replace('/', '_') }}/{{ filetree_create_eda_projects }}/{{ (project_id ~ '_') if omit_id is not defined else '' }}{{ project_name | regex_replace('/', '_') }}.yaml"
+            __dest: "{{ output_path }}/{{ project_organization | regex_replace('/', '_') }}/{{ filetree_create_eda_projects }}/{{ (project_id ~ '_') if not (omit_id | default(false) | bool) else '' }}{{ project_name | regex_replace('/', '_') }}.yaml"
             query_notification_error: "{{ query('ansible.platform.gateway_api', current_projects_asset_value.related.notification_templates_error,
                              host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
                              return_all=true, max_objects=query_eda_api_max_objects) }}"

--- a/roles/filetree_create/tasks/eda_rulebook_activations.yml
+++ b/roles/filetree_create/tasks/eda_rulebook_activations.yml
@@ -93,7 +93,7 @@
             rulebook_activation_organization: "{{ current_rulebook_activations_asset_value.organization_id | default(organization, true) }}"
             rulebook_activation_id: "{{ current_rulebook_activations_asset_value.id }}"
             rulebook_activation_name: "{{ current_rulebook_activations_asset_value.name | regex_replace('/', '_') }}"
-            __dest: "{{ output_path }}/{{ rulebook_activation_organization | regex_replace('/', '_') }}/{{ filetree_create_eda_rulebook_activations }}/{{ (rulebook_activation_id ~ '_') if omit_id is not defined else '' }}{{ rulebook_activation_name | regex_replace('/', '_') }}.yaml"
+            __dest: "{{ output_path }}/{{ rulebook_activation_organization | regex_replace('/', '_') }}/{{ filetree_create_eda_rulebook_activations }}/{{ (rulebook_activation_id ~ '_') if not (omit_id | default(false) | bool) else '' }}{{ rulebook_activation_name | regex_replace('/', '_') }}.yaml"
             query_organization_name: "{{ (query('ansible.platform.gateway_api', 'api/eda/v1/organizations/' + current_rulebook_activations_asset_value.organization_id | string,
                                                 host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
                                                 return_all=true, max_objects=query_eda_api_max_objects) | first).name

--- a/roles/filetree_create/tasks/gateway_applications.yml
+++ b/roles/filetree_create/tasks/gateway_applications.yml
@@ -73,7 +73,7 @@
         application_organization: "{{ current_applications_asset_value.summary_fields.organization.name | default(organization, true) }}"
         application_id: "{{ current_applications_asset_value.id }}"
         application_name: "{{ current_applications_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ application_organization | regex_replace('/', '_') }}/{{ filetree_create_aap_applications }}/{{ (application_id ~ '_') if omit_id is not defined else '' }}{{ application_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ application_organization | regex_replace('/', '_') }}/{{ filetree_create_aap_applications }}/{{ (application_id ~ '_') if not (omit_id | default(false) | bool) else '' }}{{ application_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ applications_lookvar }}"
       loop_control:
         loop_var: current_applications_asset_value

--- a/roles/filetree_create/tasks/gateway_authenticator_maps.yml
+++ b/roles/filetree_create/tasks/gateway_authenticator_maps.yml
@@ -2,7 +2,8 @@
 - name: "Get current Authenticator Maps from the Gateway API"
   ansible.builtin.set_fact:
     gateway_authenticator_maps_lookvar: "{{ query('ansible.platform.gateway_api', 'api/gateway/v1/authenticator_maps/',
-                                            query_params=(query_params | combine({'id': authenticator_map_id})) if authenticator_map_id is defined else query_params,
+                                            query_params=(query_params | combine({'id': authenticator_map_id} if authenticator_map_id is defined else {},
+                                              {'organization': organization_filter} if organization_filter is defined and organization_filter | length > 0 and authenticator_map_id is not defined else {})),
                                             host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
                                             return_all=true, max_objects=query_controller_api_max_objects)
                                         }}"

--- a/roles/filetree_create/tasks/gateway_teams.yml
+++ b/roles/filetree_create/tasks/gateway_teams.yml
@@ -2,7 +2,8 @@
 - name: "Get current Teams from the Gateway API"
   ansible.builtin.set_fact:
     gateway_teams_lookvar: "{{ query('ansible.platform.gateway_api', 'api/gateway/v1/teams/',
-                                     query_params=(query_params | combine({'id': team_id})) if team_id is defined else query_params,
+                                     query_params=(query_params | combine({'id': team_id} if team_id is defined else {},
+                                       {'organization': organization_id} if organization_id is defined and team_id is not defined else {})),
                                      host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
                                      return_all=true, max_objects=query_controller_api_max_objects)
                             }}"

--- a/roles/filetree_create/templates/controller_hosts.j2
+++ b/roles/filetree_create/templates/controller_hosts.j2
@@ -16,6 +16,9 @@ controller_hosts: {{ [] if current_hosts_asset_value | length == 0 }}
       {{ '{%- endraw -%}' }}
 {%   endif %}
     inventory: "{{ host.summary_fields.inventory.name | default('ToDo: The host \'' + host.name + '\' must have an associated inventory') }}"
+    enabled: {{ template_overrides_resources.host[host.name].enabled
+                | default(template_overrides_global.host.enabled)
+                | default(host.enabled | bool | lower) }}
 {%   if template_overrides_resources.host[host.name].variables is defined
       or template_overrides_global.host.variables is defined
       or (host.variables and host.variables != '---' and host.variables != '') %}

--- a/roles/filetree_create/templates/controller_inventory_sources.j2
+++ b/roles/filetree_create/templates/controller_inventory_sources.j2
@@ -67,7 +67,17 @@ controller_inventory_sources: {{ [] if current_inventory_sources_asset_value | l
     overwrite: "{{ template_overrides_resources.inventory_source[inventory_source.name].overwrite
                    | default(template_overrides_global.inventory_source.overwrite)
                    | default(inventory_source.overwrite) }}"
-{%   if template_overrides_global.inventory_source.credential is defined
+    overwrite_vars: "{{ template_overrides_resources.inventory_source[inventory_source.name].overwrite_vars
+                        | default(template_overrides_global.inventory_source.overwrite_vars)
+                        | default(inventory_source.overwrite_vars) }}"
+{%   if template_overrides_resources.inventory_source[inventory_source.name].execution_environment is defined
+      or template_overrides_global.inventory_source.execution_environment is defined
+      or inventory_source.summary_fields.execution_environment is defined %}
+    execution_environment: "{{ template_overrides_resources.inventory_source[inventory_source.name].execution_environment
+                               | default(template_overrides_global.inventory_source.execution_environment)
+                               | default(inventory_source.summary_fields.execution_environment.name) }}"
+{%   endif %}
+{%   if template_overrides_resources.inventory_source[inventory_source.name].credential is defined
       or template_overrides_global.inventory_source.credential is defined
       or inventory_source.summary_fields.credential is defined %}
     credential: "{{ template_overrides_resources.inventory_source[inventory_source.name].credential

--- a/roles/filetree_create/templates/controller_projects.j2
+++ b/roles/filetree_create/templates/controller_projects.j2
@@ -56,10 +56,10 @@ controller_projects:
 {% endif %}
 {% if (template_overrides_resources.project[current_projects_asset_value.name].default_environment is defined
       or template_overrides_global.project.default_environment is defined
-      or current_job_templates_asset_value.summary_fields.default_environment is defined) %}
+      or current_projects_asset_value.summary_fields.default_environment is defined) %}
     default_environment: "{{ template_overrides_resources.project[current_projects_asset_value.name].default_environment
                              | default(template_overrides_global.project.default_environment)
-                             | default(current_job_templates_asset_value.summary_fields.default_environment.name) }}"
+                             | default(current_projects_asset_value.summary_fields.default_environment.name) }}"
 {% endif %}
     allow_override: {{ template_overrides_resources.project[current_projects_asset_value.name].allow_override
                         | default(template_overrides_global.project.allow_override)

--- a/roles/filetree_create/templates/controller_schedules.j2
+++ b/roles/filetree_create/templates/controller_schedules.j2
@@ -19,6 +19,31 @@ controller_schedules:
     unified_job_template: "{{ template_overrides_resources.schedule[current_schedules_asset_value.name].unified_job_template
                 | default(template_overrides_global.schedule.unified_job_template)
                 | default(current_schedules_asset_value.summary_fields.unified_job_template.name) }}"
+{% if template_overrides_resources.schedule[current_schedules_asset_value.name].organization is defined
+      or template_overrides_global.schedule.organization is defined
+      or current_schedules_asset_value.summary_fields.organization is defined
+      or (organization_filter is defined and organization_filter | length > 0)
+      or current_schedules_asset_value.related.unified_job_template is defined %}
+{%   set _org = namespace(value=none) %}
+{%   if template_overrides_resources.schedule[current_schedules_asset_value.name].organization is defined
+        or template_overrides_global.schedule.organization is defined %}
+{%     set _org.value = template_overrides_resources.schedule[current_schedules_asset_value.name].organization
+                   | default(template_overrides_global.schedule.organization) %}
+{%   elif current_schedules_asset_value.summary_fields.organization is defined %}
+{%     set _org.value = current_schedules_asset_value.summary_fields.organization.name %}
+{%   elif organization_filter is defined and organization_filter | length > 0 %}
+{%     set _org.value = organization_filter %}
+{%   elif current_schedules_asset_value.related.unified_job_template is defined %}
+{%     set __ujt_for_org = query('ansible.platform.gateway_api', current_schedules_asset_value.related.unified_job_template,
+                                  host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs) %}
+{%     if (__ujt_for_org | length > 0) and __ujt_for_org[0].summary_fields.organization is defined %}
+{%       set _org.value = __ujt_for_org[0].summary_fields.organization.name %}
+{%     endif %}
+{%   endif %}
+{%   if _org.value not in [None, '', 'None'] %}
+    organization: "{{ _org.value }}"
+{%   endif %}
+{% endif %}
 {% if template_overrides_resources.schedule[current_schedules_asset_value.name].inventory is defined
       or template_overrides_global.schedule.inventory is defined
       or current_schedules_asset_value.summary_fields.inventory is defined %}

--- a/roles/filetree_create/templates/controller_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/controller_workflow_job_templates.j2
@@ -16,6 +16,13 @@ controller_workflows:
       {{ '{%- endraw -%}' }}
 {% endif %}
     organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default(organization if organization != 'ORGANIZATIONLESS' else 'ToDo: The WF \'' + current_workflow_job_templates_asset_value.name + '\' must belong to an organization') }}"
+{% if template_overrides_resources.workflow_job_template[current_workflow_job_templates_asset_value.name].inventory is defined
+      or template_overrides_global.workflow_template.inventory is defined
+      or current_workflow_job_templates_asset_value.summary_fields.inventory is defined %}
+    inventory: "{{ template_overrides_resources.workflow_job_template[current_workflow_job_templates_asset_value.name].inventory
+                   | default(template_overrides_global.workflow_template.inventory)
+                   | default(current_workflow_job_templates_asset_value.summary_fields.inventory.name) }}"
+{% endif %}
     simplified_workflow_nodes:
 {% for node in query('ansible.platform.gateway_api', 'api/controller/v2/workflow_job_template_nodes/',
                      query_params={'workflow_job_template': current_workflow_job_templates_asset_value.id},
@@ -92,6 +99,17 @@ controller_workflows:
 {%     for failure in node.failure_nodes %}
           - "{{ query('ansible.platform.gateway_api', 'api/controller/v2/workflow_job_template_nodes/'+(failure | string), host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs)[0].identifier }}"
 {%     endfor %}
+{%   endif %}
+{%   if node.related.credentials is defined %}
+{%     set query_node_credentials = query('ansible.platform.gateway_api', node.related.credentials,
+                     host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
+                     return_all=true, max_objects=query_controller_api_max_objects) %}
+{%     if query_node_credentials | length > 0 %}
+        credentials:
+{%       for credential in query_node_credentials %}
+          - "{{ credential.name }}"
+{%       endfor %}
+{%     endif %}
 {%   endif %}
 {% endfor %}
     ask_variables_on_launch: "{{ template_overrides_resources.workflow_job_template[current_workflow_job_templates_asset_value.name].ask_variables_on_launch


### PR DESCRIPTION
## Summary
- Fix `omit_id` so the boolean value is respected in output filenames (`true` omits numeric prefixes; `false` keeps them) — Resolves #302
- Apply `organization_filter` to gateway teams, gateway authenticator maps, and controller schedules — Resolves #312
- Export missing controller fields (`host.enabled`, inventory source `overwrite_vars`/`execution_environment`, project `default_environment`, workflow inventory + node credentials, schedule `organization`) — Resolves #308

## Test plan
Validated against local AAP (`localhost:8484`) with this branch via `ANSIBLE_COLLECTIONS_PATH`.

- [x] Export with `omit_id: true` and confirm filenames have no numeric ID prefix  
  (`Demo Project.yaml`, etc.)
- [x] Export with `omit_id: false` and confirm filenames keep the ID prefix  
  (`33_Demo Project.yaml`, etc.)
- [x] Export with `organization_filter` and confirm gateway teams, authenticator maps, and schedules are limited to that org  
  - teams: unfiltered 11 (Default/Satellite/Object Diff Test) → filtered `Default` only (7)  
  - authenticator_maps: unfiltered 5 → filtered `Default` only (4)  
  - schedules: unfiltered 4 system cleanup schedules → filtered `Default` = 0 (expected before seeding org schedule)
- [x] Confirm hosts export `enabled`, inventory sources export `overwrite_vars`  
  (`enabled: true`; `overwrite_vars: "False"`). `execution_environment` not present on inventory sources in this instance (nothing to export).
- [x] Confirm projects with a default EE export `default_environment`
- [x] Confirm workflows export top-level `inventory` and node `credentials` when present
- [x] Confirm schedules export `organization`

## Test results (2026-07-31 — remaining items)
Seeded on origin AAP and exported with `omit_id: true`, `organization_filter: Default`, name filters:

- **Project `Demo Project`**: set `default_environment: Default execution environment` → export  
  `default_environment: "Default execution environment"`
- **Workflow `PR320 Export Fields WF`**: inventory `Demo Inventory` + node `pr320_node_a` with credential `Demo Credential` → export  
  `inventory: "Demo Inventory"` and node `credentials: ["Demo Credential"]`
- **Schedule `PR320 Export Fields Schedule`** on `Demo Job Template` → export  
  `organization: "Default"`

Filtered export completed with `failed=0`. Artifacts under `/tmp/pr320_remaining_export2/`.

Note: a broad WFJT export on this branch still hits comment-only `extra_vars` `dict2items` failure for leftover `PR330 Comment-Only Extra Vars WFJT` (fixed separately in #330); name-filtered export avoids that unrelated regression.