### PR TITLE
docs: clarify workflow node removal needs destroy_current_nodes

### DIFF
--- a/changelogs/fragments/issue149-workflow-nodes-docs.yml
+++ b/changelogs/fragments/issue149-workflow-nodes-docs.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - object_diff - Document that Workflow Job Template node removal is not handled by
+    object_diff and requires ``destroy_current_nodes: true`` on
+    ``infra.aap_configuration.controller_workflow_job_templates`` (fixes documentation
+    gap for issue 149).

--- a/changelogs/fragments/issue149-workflow-nodes-docs.yml
+++ b/changelogs/fragments/issue149-workflow-nodes-docs.yml
@@ -1,6 +1,7 @@
 ---
 minor_changes:
-  - object_diff - Document that Workflow Job Template node removal is not handled by
+  - >-
+    object_diff - Document that Workflow Job Template node removal is not handled by
     object_diff and requires ``destroy_current_nodes: true`` on
-    ``infra.aap_configuration.controller_workflow_job_templates`` (fixes documentation
-    gap for issue 149).
+    ``infra.aap_configuration.controller_workflow_job_templates``
+    (fixes documentation gap for redhat-cop/aap_configuration_extended#149).

--- a/roles/filetree_create/automatetheautomation.md
+++ b/roles/filetree_create/automatetheautomation.md
@@ -45,7 +45,8 @@ Let's talk about how to achieve the ***Desired State*** idea, which is implement
 - teams ([Issue opened](https://issues.redhat.com/projects/AAP/issues/AAP-2393): There's no option to differentiate the externally generated teams)
 - users
 - workflow_job_templates
-  - workflow_job_template_node
+
+> **Note:** `object_diff` removes entire Workflow Job Templates that are absent from CaC. It does **not** diff individual workflow nodes. To drop nodes that remain in AAP after you remove them from the YAML definition, set `destroy_current_nodes: true` when applying the workflow with `infra.aap_configuration.controller_workflow_job_templates` (via `dispatch`). See the [object_diff README](https://github.com/redhat-cop/aap_configuration_extended/blob/devel/roles/object_diff/README.md#workflow-job-template-nodes) and [issue #149](https://github.com/redhat-cop/aap_configuration_extended/issues/149).
 
 ## Sample Organization Directory Structure
 

--- a/roles/object_diff/README.md
+++ b/roles/object_diff/README.md
@@ -34,6 +34,32 @@ $ ansible-playbook object_diff.yml --list-tags
 
 To correctly manage `roles`, they can only be defined by a super-admin organization, so all the roles in the Ansible Controller instance are managed by only one organization.
 
+## Workflow Job Template nodes
+
+`object_diff` compares **Workflow Job Templates as whole objects** (typically by name and organization). It does **not** compare or mark individual workflow nodes as `state: absent`.
+
+If a Workflow Job Template still exists in both the Controller API and your CaC list, but you removed one or more nodes from the YAML definition, `__workflow_job_templates_difference` will stay empty for that template. That is expected: the template itself is still present in code.
+
+To remove nodes that exist in AAP but are no longer defined in CaC, set `destroy_current_nodes: true` on the workflow (or rely on the equivalent option in `infra.aap_configuration.controller_workflow_job_templates`) when applying configuration via `dispatch`. See the [controller_workflow_job_templates role documentation](https://github.com/redhat-cop/infra.aap_configuration/blob/devel/roles/controller_workflow_job_templates/README.md) for details.
+
+Example:
+
+```yaml
+controller_workflows:
+  - name: My Workflow
+    organization: Default
+    destroy_current_nodes: true
+    workflow_nodes:
+      - identifier: node_a
+        unified_job_template: Job Template A
+        success_nodes:
+          - node_b
+      - identifier: node_b
+        unified_job_template: Job Template B
+```
+
+Related: [issue #149](https://github.com/redhat-cop/aap_configuration_extended/issues/149).
+
 ## Example Playbook
 
 ```bash
@@ -132,3 +158,4 @@ GPLv3+
 - Issues:
   - Users and Teams must be managed by users with privileges.
   - Due to the Team Object doesn't return from API any field related to external account on Controller API, which help to filter if the teams comes from an External Source and not to be deleted by the Object Diff Ansible automation process.
+  - Workflow Job Template **nodes** are outside the scope of `object_diff`. Removing a node from CaC does not produce an absent entry in `__workflow_job_templates_difference`; use `destroy_current_nodes: true` when applying the workflow (see [Workflow Job Template nodes](#workflow-job-template-nodes)).


### PR DESCRIPTION
## Summary
- Document that `object_diff` compares whole Workflow Job Templates, not individual nodes.
- Clarify that removing orphaned workflow nodes requires `destroy_current_nodes: true` via `infra.aap_configuration.controller_workflow_job_templates`.
- Correct `automatetheautomation.md`, which incorrectly listed `workflow_job_template_node` under object_diff desired-state.
- Quote the changelog fragment so ``destroy_current_nodes: true`` is valid YAML.
- Resolves #149.

## Test plan
- [x] Review `roles/object_diff/README.md` section “Workflow Job Template nodes”
- [x] Review note in `roles/filetree_create/automatetheautomation.md`
- [x] Confirm changelog fragment renders as intended

## Test results (2026-07-30)
- **object_diff README**: New section explains whole-WFJT diffing, why `__workflow_job_templates_difference` stays empty when only nodes change, and the `destroy_current_nodes: true` example. Cross-linked from Known Issues. Matches upstream `controller_workflow_job_templates` option.
- **automatetheautomation.md**: Removed incorrect nested `workflow_job_template_node` under desired-state; note points to object_diff README and #149.
- **Changelog**: Original fragment failed YAML load (`destroy_current_nodes: true` colon). Fixed with a folded quoted scalar (`>-`) and unspaced `repo#149`; parses under `minor_changes` with full text intact.