### PR TITLE
fix(filetree_create): export comment-only extra_vars without dict2items failure

### DIFF
--- a/changelogs/fragments/issue321-comment-only-extra-vars.yml
+++ b/changelogs/fragments/issue321-comment-only-extra-vars.yml
@@ -2,4 +2,5 @@
 bugfixes:
   - filetree_create - Export job/workflow template ``extra_vars`` that contain only
     YAML comments without failing on ``dict2items`` when ``from_yaml`` returns
-    ``None`` (fixes #321; regression from #270 after #226).
+    ``None`` (fixes redhat-cop/aap_configuration_extended#321; regression from
+    redhat-cop/aap_configuration_extended#270 after redhat-cop/aap_configuration_extended#226).

--- a/changelogs/fragments/issue321-comment-only-extra-vars.yml
+++ b/changelogs/fragments/issue321-comment-only-extra-vars.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - filetree_create - Export job/workflow template ``extra_vars`` that contain only
+    YAML comments without failing on ``dict2items`` when ``from_yaml`` returns
+    ``None`` (fixes #321; regression from #270 after #226).

--- a/roles/filetree_create/templates/controller_job_templates.j2
+++ b/roles/filetree_create/templates/controller_job_templates.j2
@@ -130,17 +130,19 @@ controller_templates:
                                       | default(template_overrides_global.job_template.ask_instance_groups_on_launch)
                                       | default(current_job_templates_asset_value.ask_instance_groups_on_launch | bool | lower) }}
 {% endif %}
-{% if template_overrides_resources.job_template[current_job_templates_asset_value.name].extra_vars is defined
-      or template_overrides_global.job_template.extra_vars is defined
-      or (current_job_templates_asset_value.extra_vars and (
-        (current_job_templates_asset_value.extra_vars is mapping and current_job_templates_asset_value.extra_vars | length > 0)
-        or (current_job_templates_asset_value.extra_vars is string and current_job_templates_asset_value.extra_vars | length > 0)
-      )) %}
-    extra_vars:
-{%   set __job_template_extra_vars = template_overrides_resources.job_template[current_job_templates_asset_value.name].extra_vars
+{% set __job_template_extra_vars = template_overrides_resources.job_template[current_job_templates_asset_value.name].extra_vars
                              | default(template_overrides_global.job_template.extra_vars)
-                             | default(current_job_templates_asset_value.extra_vars) %}
-{%   set extra_vars_contents = __job_template_extra_vars if __job_template_extra_vars is mapping or (__job_template_extra_vars | type_debug) == 'list' else (__job_template_extra_vars | from_yaml) %}
+                             | default(current_job_templates_asset_value.extra_vars)
+                             | default('') %}
+{% if __job_template_extra_vars is mapping or (__job_template_extra_vars | type_debug) == 'list' %}
+{%   set extra_vars_contents = __job_template_extra_vars %}
+{% elif __job_template_extra_vars is string and (__job_template_extra_vars | length > 0) %}
+{%   set extra_vars_contents = __job_template_extra_vars | from_yaml %}
+{% else %}
+{%   set extra_vars_contents = none %}
+{% endif %}
+{% if extra_vars_contents is mapping and (extra_vars_contents | length > 0) %}
+    extra_vars:
 {%   for extra_vars_item in (extra_vars_contents | dict2items) if (
         extra_vars_item.value == ''
         or ((extra_vars_item.value | string | length) > 0 and (extra_vars_item.value | string) is not match('None'))
@@ -157,6 +159,9 @@ controller_templates:
 
 {%     endif %}
 {%   endfor %}
+{% elif __job_template_extra_vars is string and (__job_template_extra_vars | length > 0) %}
+{# Comment-only (or otherwise non-mapping) YAML: keep original text; from_yaml is None and must not hit dict2items #}
+    extra_vars: {{ '"{%- raw -%}' }}{{ (__job_template_extra_vars | regex_replace("\n", "\\\\n") | regex_replace('"', '\\"')) | regex_replace('\\\\(?!n|")', '\\\\\\\\') }}{{ '{%- endraw -%}"' }}
 {% else %}
     extra_vars: ""
 {% endif %}

--- a/roles/filetree_create/templates/controller_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/controller_workflow_job_templates.j2
@@ -115,17 +115,19 @@ controller_workflows:
     webhook_service: "{{ template_overrides_resources.workflow_job_template[current_workflow_job_templates_asset_value.name].webhook_service
                          | default(template_overrides_global.workflow_template.webhook_service)
                          | default(current_workflow_job_templates_asset_value.webhook_service) }}"
-{% if template_overrides_resources.workflow_job_template[current_workflow_job_templates_asset_value.name].extra_vars is defined
-      or template_overrides_global.workflow_template.extra_vars is defined
-      or (current_workflow_job_templates_asset_value.extra_vars and (
-        (current_workflow_job_templates_asset_value.extra_vars is mapping and current_workflow_job_templates_asset_value.extra_vars | length > 0)
-        or (current_workflow_job_templates_asset_value.extra_vars is string and current_workflow_job_templates_asset_value.extra_vars | length > 0)
-      )) %}
-    extra_vars:
-{%   set __workflow_extra_vars = template_overrides_resources.workflow_job_template[current_workflow_job_templates_asset_value.name].extra_vars
+{% set __workflow_extra_vars = template_overrides_resources.workflow_job_template[current_workflow_job_templates_asset_value.name].extra_vars
                                  | default(template_overrides_global.workflow_template.extra_vars)
-                                 | default(current_workflow_job_templates_asset_value.extra_vars) %}
-{%   set extra_vars_contents = __workflow_extra_vars if __workflow_extra_vars is mapping or (__workflow_extra_vars | type_debug) == 'list' else (__workflow_extra_vars | from_yaml) %}
+                                 | default(current_workflow_job_templates_asset_value.extra_vars)
+                                 | default('') %}
+{% if __workflow_extra_vars is mapping or (__workflow_extra_vars | type_debug) == 'list' %}
+{%   set extra_vars_contents = __workflow_extra_vars %}
+{% elif __workflow_extra_vars is string and (__workflow_extra_vars | length > 0) %}
+{%   set extra_vars_contents = __workflow_extra_vars | from_yaml %}
+{% else %}
+{%   set extra_vars_contents = none %}
+{% endif %}
+{% if extra_vars_contents is mapping and (extra_vars_contents | length > 0) %}
+    extra_vars:
 {%   for extra_vars_item in (extra_vars_contents | dict2items) if (
         extra_vars_item.value == ''
         or ((extra_vars_item.value | string | length) > 0 and (extra_vars_item.value | string) is not match('None'))
@@ -141,6 +143,9 @@ controller_workflows:
       {{ extra_vars_item.key }}: {{ '"{%- raw -%}' }}{{ (extra_vars_item.value | regex_replace("\n", "\\\\n") | regex_replace('"', '\\"')) | regex_replace('\\\\(?!n|")', '\\\\\\\\') }}{{ '{%- endraw -%}"' }}
 {%     endif %}
 {%   endfor %}
+{% elif __workflow_extra_vars is string and (__workflow_extra_vars | length > 0) %}
+{# Comment-only (or otherwise non-mapping) YAML: keep original text; from_yaml is None and must not hit dict2items #}
+    extra_vars: {{ '"{%- raw -%}' }}{{ (__workflow_extra_vars | regex_replace("\n", "\\\\n") | regex_replace('"', '\\"')) | regex_replace('\\\\(?!n|")', '\\\\\\\\') }}{{ '{%- endraw -%}"' }}
 {% else %}
     extra_vars: ""
 {% endif %}


### PR DESCRIPTION
## Summary
- Fix `filetree_create` export of job/workflow template `extra_vars` that contain only YAML comments.
- When `from_yaml` returns `None`, keep the original text instead of calling `dict2items` (regression from #270 after #226).
- Changelog fragment uses unspaced `repo#issue` refs so YAML does not treat `#321` as a comment.
- Resolves #321.

## Test plan
- [x] Ansible template render: comment-only `extra_vars` exports as string (no `dict2items` error)
- [x] Mapping / YAML key-value `extra_vars` still expand to nested keys
- [x] Empty `extra_vars` still exports as `""`
- [x] Export a JT/WFJT from AAP with comment-only extra vars via `filetree_create` and confirm success

## Test results (2026-07-30)
- **Template unit renders** (same guard as JT/WFJT templates): comment-only → string; `foo: bar` → nested keys; empty → `""`.
- **Live AAP (origin `localhost:8484`)**
  - Created `PR330 Comment-Only Extra Vars JT` and `… WFJT` in org `Default`.
  - Set `extra_vars` via Controller API PATCH to comment-only YAML text (`# only comments for issue 321`…).
  - `filetree_create` with `input_tag: [controller_job_templates, controller_workflow_job_templates]` and name filters completed with `failed=0`.
  - Export kept comments as a raw string, e.g.
    `extra_vars: "{%- raw -%}# only comments for issue 321\n# foo should not be a key{%- endraw -%}"`
    under `Default/controller_job_templates.d/` and `Default/controller_workflow_job_templates.d/`.