### PR TITLE
fix(filetree_create): document secure_logging and honor aap_configuration_secure_logging

### DIFF
--- a/changelogs/fragments/issue304-secure-logging-docs.yml
+++ b/changelogs/fragments/issue304-secure-logging-docs.yml
@@ -2,4 +2,5 @@
 bugfixes:
   - filetree_create - Document ``*_secure_logging`` role variables in the README
     and align defaults with ``aap_configuration_secure_logging`` (with legacy
-    ``controller_configuration_secure_logging`` fallback) (fixes #304).
+    ``controller_configuration_secure_logging`` fallback)
+    (fixes redhat-cop/aap_configuration_extended#304).

--- a/changelogs/fragments/issue304-secure-logging-docs.yml
+++ b/changelogs/fragments/issue304-secure-logging-docs.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - filetree_create - Document ``*_secure_logging`` role variables in the README
+    and align defaults with ``aap_configuration_secure_logging`` (with legacy
+    ``controller_configuration_secure_logging`` fallback) (fixes #304).

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -55,6 +55,21 @@ The following variables are required for that role to work properly:
 | `hub_ee_repository_remote` | N/A | no | str | Filter the repositories to be exported from the PAH throuhg it's repository's remote field. |
 | `hub_role_name` | N/A | no | str | Filter the Roles to be exported from the PAH through it's name. |
 
+### Secure Logging Variables
+
+These variables control Ansible `no_log` on tasks that may touch credentials or tokens.
+If neither a role-specific nor a shared variable is set, secure logging defaults to `false`.
+
+Each `*_filetree_create_secure_logging` variable defaults to `aap_configuration_secure_logging`, then to the legacy `controller_configuration_secure_logging`. That lets you toggle secure logging for the whole CaC suite with one variable, or override it per component (Controller / EDA / Hub).
+
+| Variable Name | Default Value | Required | Type | Description |
+| :------------ | :-----------: | :------: | :------: | :---------- |
+| `controller_configuration_filetree_create_secure_logging` | `false` (via shared cascade) | no | bool | Whether to hide Controller export task output from the log (`no_log`). |
+| `eda_configuration_filetree_create_secure_logging` | `false` (via shared cascade) | no | bool | Whether to hide EDA export task output from the log (`no_log`). |
+| `hub_configuration_filetree_create_secure_logging` | `false` (via shared cascade) | no | bool | Whether to hide Hub export task output from the log (`no_log`). |
+| `aap_configuration_secure_logging` | `false` | no | bool | Shared secure-logging default across `infra.aap_configuration` / `infra.aap_configuration_extended` roles. |
+| `controller_configuration_secure_logging` | `false` | no | bool | Legacy shared default; used when `aap_configuration_secure_logging` is unset. |
+
 ## Dependencies
 
 A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.

--- a/roles/filetree_create/defaults/main.yml
+++ b/roles/filetree_create/defaults/main.yml
@@ -55,9 +55,9 @@ export_related_objects: false
 skip_inventory_sources: false
 skip_inventory_hosts: false
 skip_inventory_groups: false
-controller_configuration_filetree_create_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
-eda_configuration_filetree_create_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
-hub_configuration_filetree_create_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
+controller_configuration_filetree_create_secure_logging: "{{ aap_configuration_secure_logging | default(controller_configuration_secure_logging | default(false)) }}"
+eda_configuration_filetree_create_secure_logging: "{{ aap_configuration_secure_logging | default(controller_configuration_secure_logging | default(false)) }}"
+hub_configuration_filetree_create_secure_logging: "{{ aap_configuration_secure_logging | default(controller_configuration_secure_logging | default(false)) }}"
 
 secrets_as_variables: true
 secrets_as_variables_prefix: "vaulted"

--- a/roles/filetree_create/meta/argument_specs.yml
+++ b/roles/filetree_create/meta/argument_specs.yml
@@ -43,15 +43,30 @@ argument_specs:
 
       # No_log variables
       controller_configuration_filetree_create_secure_logging:
-        default: "{{ controller_configuration_secure_logging | default(false) }}"
+        default: "{{ aap_configuration_secure_logging | default(controller_configuration_secure_logging | default(false)) }}"
         required: false
         type: bool
-        description: Whether or not to include the sensitive tasks from this role in the log. Set this value to `true` if you will be providing your sensitive values from elsewhere.
+        description: Whether or not to hide Controller export task output from the log (`no_log`). Defaults to `aap_configuration_secure_logging`, then legacy `controller_configuration_secure_logging`.
+      eda_configuration_filetree_create_secure_logging:
+        default: "{{ aap_configuration_secure_logging | default(controller_configuration_secure_logging | default(false)) }}"
+        required: false
+        type: bool
+        description: Whether or not to hide EDA export task output from the log (`no_log`). Defaults to `aap_configuration_secure_logging`, then legacy `controller_configuration_secure_logging`.
+      hub_configuration_filetree_create_secure_logging:
+        default: "{{ aap_configuration_secure_logging | default(controller_configuration_secure_logging | default(false)) }}"
+        required: false
+        type: bool
+        description: Whether or not to hide Hub export task output from the log (`no_log`). Defaults to `aap_configuration_secure_logging`, then legacy `controller_configuration_secure_logging`.
+      aap_configuration_secure_logging:
+        default: false
+        required: false
+        type: bool
+        description: Shared secure-logging default across `infra.aap_configuration` / `infra.aap_configuration_extended` roles.
       controller_configuration_secure_logging:
         default: false
         required: false
         type: bool
-        description: This variable enables secure logging across all roles as a default.
+        description: Legacy shared secure-logging default used when `aap_configuration_secure_logging` is unset.
 
       # Generic across all roles
       controller_state:


### PR DESCRIPTION
## Summary
- Document Controller / EDA / Hub `*_filetree_create_secure_logging` variables in the `filetree_create` README (they were only shown in examples).
- Align defaults and `argument_specs` with `aap_configuration_secure_logging`, keeping the legacy `controller_configuration_secure_logging` fallback.
- Changelog fragment uses the unspaced `repo#issue` form so YAML does not treat `#304` as a comment.
- Resolves #304.

## Test plan
- [x] Cascade resolves to `false` when unset
- [x] `aap_configuration_secure_logging=true` and legacy `controller_configuration_secure_logging=true` both take effect
- [x] Skim README “Secure Logging Variables” section for clarity
- [x] Confirm changelog fragment renders under bugfixes

## Test results (2026-07-30)
- **Cascade (Ansible asserts on the same Jinja as `defaults/main.yml`)**
  - unset → `False` for controller / EDA / Hub `*_filetree_create_secure_logging`
  - `aap_configuration_secure_logging=true` → all three `True`
  - `controller_configuration_secure_logging=true` only (legacy) → all three `True`
  - explicit `aap_configuration_secure_logging=false` wins over legacy `true`
- **README**: “Secure Logging Variables” documents the cascade and all five vars clearly.
- **Changelog**: fragment is under `bugfixes:`; initial `(fixes #304)` was truncated by YAML (`#` comment after space). Fixed to `(fixes redhat-cop/aap_configuration_extended#304)`; `Validate Changelog` pre-commit hook passed.