### PR TITLE
fix(filetree_create): export missing organization fields into aap_organizations

### DIFF
--- a/changelogs/fragments/issue196-org-export-fields.yml
+++ b/changelogs/fragments/issue196-org-export-fields.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - filetree_create - Export organization ``max_hosts``, ``custom_virtualenv``,
+    ``default_environment``, ``galaxy_credentials``, and ``instance_groups``
+    (by name) into ``aap_organizations`` alongside existing notification
+    templates (fixes #196).

--- a/roles/filetree_create/tasks/controller_organizations.yml
+++ b/roles/filetree_create/tasks/controller_organizations.yml
@@ -28,18 +28,30 @@
         marker: ""
         block: "{{ lookup('template', 'templates/controller_organizations.j2') }}"
       vars:
+        query_galaxy_credentials: "{{ query('ansible.platform.gateway_api', current_organization.related.galaxy_credentials,
+                         host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
+                         return_all=true, max_objects=query_controller_api_max_objects)
+                         if current_organization.related.galaxy_credentials is defined else [] }}"
+        query_instance_groups: "{{ query('ansible.platform.gateway_api', current_organization.related.instance_groups,
+                         host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
+                         return_all=true, max_objects=query_controller_api_max_objects)
+                         if current_organization.related.instance_groups is defined else [] }}"
         query_notification_error: "{{ query('ansible.platform.gateway_api', current_organization.related.notification_templates_error,
                          host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
-                         return_all=true, max_objects=query_controller_api_max_objects) }}"
+                         return_all=true, max_objects=query_controller_api_max_objects)
+                         if current_organization.related.notification_templates_error is defined else [] }}"
         query_notification_started: "{{ query('ansible.platform.gateway_api', current_organization.related.notification_templates_started,
                          host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
-                         return_all=true, max_objects=query_controller_api_max_objects) }}"
+                         return_all=true, max_objects=query_controller_api_max_objects)
+                         if current_organization.related.notification_templates_started is defined else [] }}"
         query_notification_success: "{{ query('ansible.platform.gateway_api', current_organization.related.notification_templates_success,
                          host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
-                         return_all=true, max_objects=query_controller_api_max_objects) }}"
+                         return_all=true, max_objects=query_controller_api_max_objects)
+                         if current_organization.related.notification_templates_success is defined else [] }}"
         query_notification_approvals: "{{ query('ansible.platform.gateway_api', current_organization.related.notification_templates_approvals,
                          host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
-                         return_all=true, max_objects=query_controller_api_max_objects) }}"
+                         return_all=true, max_objects=query_controller_api_max_objects)
+                         if current_organization.related.notification_templates_approvals is defined else [] }}"
         last_organization: "{{ current_organization_index == ((orgs_lookvar | length) - 1) }}"
       loop: "{{ orgs_lookvar }}"
       loop_control:
@@ -76,18 +88,30 @@
         mode: '0644'
       vars:
         __dest: "{{ output_path }}/{{ current_organization.name | regex_replace('/', '_') }}/controller_organization.yaml"
+        query_galaxy_credentials: "{{ query('ansible.platform.gateway_api', current_organization.related.galaxy_credentials,
+                         host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
+                         return_all=true, max_objects=query_controller_api_max_objects)
+                         if current_organization.related.galaxy_credentials is defined else [] }}"
+        query_instance_groups: "{{ query('ansible.platform.gateway_api', current_organization.related.instance_groups,
+                         host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
+                         return_all=true, max_objects=query_controller_api_max_objects)
+                         if current_organization.related.instance_groups is defined else [] }}"
         query_notification_error: "{{ query('ansible.platform.gateway_api', current_organization.related.notification_templates_error,
                          host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
-                         return_all=true, max_objects=query_controller_api_max_objects) }}"
+                         return_all=true, max_objects=query_controller_api_max_objects)
+                         if current_organization.related.notification_templates_error is defined else [] }}"
         query_notification_started: "{{ query('ansible.platform.gateway_api', current_organization.related.notification_templates_started,
                          host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
-                         return_all=true, max_objects=query_controller_api_max_objects) }}"
+                         return_all=true, max_objects=query_controller_api_max_objects)
+                         if current_organization.related.notification_templates_started is defined else [] }}"
         query_notification_success: "{{ query('ansible.platform.gateway_api', current_organization.related.notification_templates_success,
                          host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
-                         return_all=true, max_objects=query_controller_api_max_objects) }}"
+                         return_all=true, max_objects=query_controller_api_max_objects)
+                         if current_organization.related.notification_templates_success is defined else [] }}"
         query_notification_approvals: "{{ query('ansible.platform.gateway_api', current_organization.related.notification_templates_approvals,
                          host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
-                         return_all=true, max_objects=query_controller_api_max_objects) }}"
+                         return_all=true, max_objects=query_controller_api_max_objects)
+                         if current_organization.related.notification_templates_approvals is defined else [] }}"
       loop: "{{ orgs_lookvar }}"
       loop_control:
         loop_var: current_organization

--- a/roles/filetree_create/templates/controller_organizations.j2
+++ b/roles/filetree_create/templates/controller_organizations.j2
@@ -2,36 +2,72 @@
 ---
 aap_organizations:
 {% endif %}
+{% set __empty_values = [None, '', "None", [], {}, [{}]] %}
   - name: "{{ current_organization.name }}"
+{% set __org_description = template_overrides_resources.organization[current_organization.name].description
+                     | default(template_overrides_global.organization.description)
+                     | default(current_organization.description) | regex_replace("'", "''") %}
+{% if __org_description not in __empty_values %}
     description: |-
       {{ '{%- raw -%}' }}
-      {{ template_overrides_resources.organization[current_organization.name].description
-                     | default(template_overrides_global.organization.description)
-                     | default(current_organization.description) | regex_replace("'", "''") }}
+      {{ __org_description }}
       {{ '{%- endraw -%}' }}
-{% if query_notification_error | length > 0 %}
+{% endif %}
+{% set __org_max_hosts = template_overrides_resources.organization[current_organization.name].max_hosts
+                     | default(template_overrides_global.organization.max_hosts)
+                     | default(current_organization.max_hosts) %}
+{% if __org_max_hosts is defined and __org_max_hosts not in __empty_values %}
+    max_hosts: {{ __org_max_hosts }}
+{% endif %}
+{% set __org_custom_virtualenv = template_overrides_resources.organization[current_organization.name].custom_virtualenv
+                     | default(template_overrides_global.organization.custom_virtualenv)
+                     | default(current_organization.custom_virtualenv) %}
+{% if __org_custom_virtualenv is defined and __org_custom_virtualenv not in __empty_values %}
+    custom_virtualenv: "{{ __org_custom_virtualenv }}"
+{% endif %}
+{% if template_overrides_resources.organization[current_organization.name].default_environment is defined
+      or template_overrides_global.organization.default_environment is defined
+      or (current_organization.summary_fields.default_environment is defined
+          and current_organization.summary_fields.default_environment.name is defined) %}
+    default_environment: "{{ template_overrides_resources.organization[current_organization.name].default_environment
+                             | default(template_overrides_global.organization.default_environment)
+                             | default(current_organization.summary_fields.default_environment.name) }}"
+{% endif %}
+{% if query_galaxy_credentials | default([]) | length > 0 %}
+    galaxy_credentials:
+{%   for galaxy_credential in query_galaxy_credentials %}
+      - "{{ galaxy_credential.name }}"
+{%   endfor %}
+{% endif %}
+{% if query_instance_groups | default([]) | length > 0 %}
+    instance_groups:
+{%   for instance_group in query_instance_groups %}
+      - "{{ instance_group.name }}"
+{%   endfor %}
+{% endif %}
+{% if query_notification_error | default([]) | length > 0 %}
     notification_templates_error:
-{% for notification_error in query_notification_error %}
+{%   for notification_error in query_notification_error %}
       - "{{ notification_error.name }}"
-{% endfor %}
+{%   endfor %}
 {% endif %}
-{% if query_notification_started | length > 0 %}
+{% if query_notification_started | default([]) | length > 0 %}
     notification_templates_started:
-{% for notification_started in query_notification_started %}
+{%   for notification_started in query_notification_started %}
       - "{{ notification_started.name }}"
-{% endfor %}
+{%   endfor %}
 {% endif %}
-{% if query_notification_success | length > 0 %}
+{% if query_notification_success | default([]) | length > 0 %}
     notification_templates_success:
-{% for notification_success in query_notification_success %}
+{%   for notification_success in query_notification_success %}
       - "{{ notification_success.name }}"
-{% endfor %}
+{%   endfor %}
 {% endif %}
-{% if query_notification_approvals | length > 0 %}
+{% if query_notification_approvals | default([]) | length > 0 %}
     notification_templates_approvals:
-{% for notification_approval in query_notification_approvals %}
+{%   for notification_approval in query_notification_approvals %}
       - "{{ notification_approval.name }}"
-{% endfor %}
+{%   endfor %}
 {% endif %}
 {% if last_organization | default(true) | bool %}
 ...


### PR DESCRIPTION
## Summary
- Export organization `max_hosts`, `custom_virtualenv`, `default_environment`, `galaxy_credentials`, and `instance_groups` (names) into `aap_organizations`.
- Keep existing notification template exports; skip empty description/virtualenv.
- Resolves #196 (also covers the gap reported in closed #309).

## Test plan
- [x] Template render with max_hosts / EE / galaxy creds / instance groups
- [x] Bare org still exports (`max_hosts: 0` when set; no empty lists)
- [x] Export from AAP (`localhost:8484`) org `PR332 Test Org` with `max_hosts=123` + default EE + galaxy credential + instance group → YAML confirmed (`max_hosts`, `default_environment`, `galaxy_credentials`, `instance_groups`)
- [x] `filetree_read` → `dispatch` roundtrip to dest (`192.168.122.247`) — org created with `max_hosts=123`, EE `Default execution environment`, galaxy `Ansible Galaxy`, IG `default`