### PR TITLE
docs: clarify filetree_create for capturing existing objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ A complete example of how to use all of the roles present in the collection is a
 
 The input data can be organized in a very flexible way, letting the user use anything from a single file to an entire file tree to store the controller objects definitions, which could be used as a logical segregation of different applications, as needed in real scenarios.
 
+### Capturing existing objects (ClickOps → CaC)
+
+To export objects already present in AAP into YAML for `infra.aap_configuration.dispatch`, use the [`filetree_create`](roles/filetree_create/README.md) role (then [`filetree_read`](roles/filetree_read/README.md) to load the tree). See [docs/filetree_create_capture.md](docs/filetree_create_capture.md) for name filters, examples, and known gaps.
+
 ### Controller Export
 
 The awx command line can export json that is compatible with this collection.

--- a/changelogs/fragments/issue110-filetree-create-capture-docs.yml
+++ b/changelogs/fragments/issue110-filetree-create-capture-docs.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - >-
+    docs - Clarify that ``filetree_create`` is the supported way to capture
+    existing AAP objects as Configuration as Code, including name filters and
+    remaining gaps (related to redhat-cop/aap_configuration_extended#110).

--- a/docs/filetree_create_capture.md
+++ b/docs/filetree_create_capture.md
@@ -1,0 +1,56 @@
+# Capturing existing AAP objects as Configuration as Code
+
+The [`filetree_create`](../roles/filetree_create/README.md) role is the supported way to capture objects that already exist in Ansible Automation Platform and turn them into YAML suitable for `infra.aap_configuration.dispatch` (via [`filetree_read`](../roles/filetree_read/README.md)).
+
+Use it when you want to move from ClickOps / GUI-created objects to GitOps, or when you need a starting definition for an object type without browsing the API explorer by hand.
+
+## What it does today
+
+- Exports Controller, Gateway, EDA, and Hub objects that the collection supports into a file tree (or flattened YAML files with `flatten_output: true`).
+- Filters by object **name** for common types (prefer names over numeric IDs), for example:
+  - `organization_filter` / `organization_name`
+  - `project_name`, `inventory_name`
+  - `job_template_name`, `workflow_job_template_name`
+  - Hub filters such as `hub_collection_name`, `hub_ee_repository_name`
+- Narrows by organization with `organization_filter`.
+- Limits which object types run with `input_tag`.
+- Exports related objects for a single JT / WFJT when `export_related_objects` is enabled (see the role README PRE → PRO examples).
+- Omits numeric IDs from filenames when `omit_id: true` (recommended for CaC).
+
+Example — export one inventory by name:
+
+```yaml
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    aap_hostname: "{{ aap_hostname }}"
+    aap_username: "{{ aap_username }}"
+    aap_password: "{{ aap_password }}"
+    aap_validate_certs: false
+    output_path: /tmp/filetree_output
+    omit_id: true
+    inventory_name: "My Inventory"
+    input_tag:
+      - controller_inventories
+  roles:
+    - infra.aap_configuration_extended.filetree_create
+```
+
+Then import with `filetree_read` + `infra.aap_configuration.dispatch` (see `playbooks/import_filetree.yml`).
+
+## Gaps that remain (not implemented here)
+
+The original enhancement request also asked for:
+
+1. **Stdout-only capture** — emit the YAML via `ansible.builtin.debug` (or similar) without writing files. Today the role always writes under `output_path`. Workarounds: `flatten_output: true` and read the generated file(s), or pipe/cat after the run.
+2. **Name filters for every object type** — several types already support `*_name` filters; others still export the full type (optionally limited by org / tags). Broader per-type name selectors can be added as follow-up enhancements.
+3. **Strip API defaults aggressively** — templates already omit many empty / unset fields; they are not a full “diff against factory defaults” for every attribute.
+
+Those items can be separate issues/PRs if still needed; they are not blockers for using `filetree_create` as the capture tool.
+
+## See also
+
+- [filetree_create README](../roles/filetree_create/README.md)
+- [filetree_read README](../roles/filetree_read/README.md)
+- [EXPORT_README.md](../EXPORT_README.md) (awx / ansible.controller export alternatives)


### PR DESCRIPTION
## Summary
- Add `docs/filetree_create_capture.md` explaining that `filetree_create` is the supported ClickOps → CaC capture path.
- Link it from the collection README.
- Document existing name filters and remaining gaps (stdout-only export, broader per-type name filters, aggressive default stripping).

Closes #110

## Conflict note
Touches only root `README.md`, new `docs/` page, and a changelog fragment — should not conflict with open filetree PRs.

## Test plan
- [ ] Read the new doc for accuracy against current `filetree_create` variables
- [ ] Confirm root README link resolves


Made with [Cursor](https://cursor.com)