### PR TITLE
fix(filetree_create): export null/empty controller_settings keys

### DIFF
--- a/changelogs/fragments/issue342-controller-settings-export.yml
+++ b/changelogs/fragments/issue342-controller-settings-export.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - 'filetree_create - Export ``AWX_ANSIBLE_CALLBACK_PLUGINS`` and ``DEFAULT_EXECUTION_ENVIRONMENT`` in controller_settings even when empty or null. Fixes #342.'

--- a/changelogs/fragments/issue342-controller-settings-export.yml
+++ b/changelogs/fragments/issue342-controller-settings-export.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - 'filetree_create - Export ``AWX_ANSIBLE_CALLBACK_PLUGINS`` and ``DEFAULT_EXECUTION_ENVIRONMENT`` in controller_settings even when empty or null. Fixes #342.'
+  - 'filetree_create - Export ``AWX_ANSIBLE_CALLBACK_PLUGINS`` and ``DEFAULT_EXECUTION_ENVIRONMENT`` in controller_settings via ``template_overrides_global.controller_setting`` defaults. Fixes #342.'

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -46,8 +46,8 @@ The following variables are required for that role to work properly:
 | `skip_inventory_sources` | False | no | bool | Whether the inventory sources should be exported with inventory. |
 | `skip_inventory_hosts` | False | no | bool | Whether the inventory hosts should be exported with inventory. |
 | `skip_inventory_groups` | False | no | bool | Whether the inventory groups should be exported with inventory. |
-| `templates_overrides_resources` | N/A | no | dict | Whether the certain objects should be modified during the export. |
-| `templates_overrides_global` | N/A | no | dict | Whether the all objects should be modified during the export. |
+| `template_overrides_resources` | N/A | no | dict | Per-object export overrides (resource dict takes precedence over global). |
+| `template_overrides_global` | see defaults | no | dict | Global export overrides applied to all objects of a given type. Includes `controller_setting` defaults for keys that must export even when empty (see below). |
 | `hub_collection_name` | N/A | no | str | Filter the collections to be exported from the PAH through it's name. |
 | `hub_collection_namespace` | N/A | no | str | Filter the collections to be exported from the PAH through it's namespace. |
 | `hub_collection_remote_name` | N/A | no | str | Filter the collection remotes to be exported from the PAH through it's name. |
@@ -261,12 +261,12 @@ This example will export all object but some with modifications:
     aap_hostname: "{{ vault_aap_hostname | default(lookup('env', 'CONTROLLER_HOST')) }}"
     aap_validate_certs: "{{ vault_aap_validate_certs | default(lookup('env', 'CONTROLLER_VERIFY_SSL')) }}"
 
-    templates_overrides_resources:
+    template_overrides_resources:
       job_template:
         job_template_example:
           scm_branch: "dev"
 
-    templates_overrides_global:
+    template_overrides_global:
       job_template:
         scm_branch: "main"
       project:
@@ -279,6 +279,31 @@ This example will export all object but some with modifications:
 
 ...
 ```
+
+### Controller settings export defaults
+
+Role defaults include `template_overrides_global.controller_setting` so `AWX_ANSIBLE_CALLBACK_PLUGINS` and `DEFAULT_EXECUTION_ENVIRONMENT` are always written to `controller_settings.yaml`, even when the API omits them from `settings/changed` or returns an empty value. Use the same mechanism to add more keys or override values at export time (per key via `template_overrides_resources.controller_setting.<SETTING_NAME>`).
+
+**Important:** play-level `template_overrides_global` replaces the role default dict for that variable. If you set `template_overrides_global` in your playbook, include a `controller_setting` block (or merge with role defaults) so those export defaults are not lost. For example:
+
+```yaml
+template_overrides_global:
+  job_template:
+    scm_branch: main
+  controller_setting:
+    AWX_ANSIBLE_CALLBACK_PLUGINS: []
+    DEFAULT_EXECUTION_ENVIRONMENT: ""
+```
+
+Or merge explicitly:
+
+```yaml
+template_overrides_global: "{{ (template_overrides_global | default({})) | combine({
+  'job_template': {'scm_branch': 'main'},
+}, recursive=True) }}"
+```
+
+When using `combine`, keep the `controller_setting` keys from role defaults unless you intentionally override them.
 
 ## Usage example for the `secrets_as_variables` feature
 

--- a/roles/filetree_create/defaults/main.yml
+++ b/roles/filetree_create/defaults/main.yml
@@ -66,6 +66,12 @@ hub_configuration_filetree_create_secure_logging: "{{ aap_configuration_secure_l
 secrets_as_variables: true
 secrets_as_variables_prefix: "vaulted"
 
+# Controller settings keys exported even when null or an empty list (defaults omitted
+# from settings/changed/ and filtered as empty by the export template).
+settings_export_include_empty:
+  - AWX_ANSIBLE_CALLBACK_PLUGINS
+  - DEFAULT_EXECUTION_ENVIRONMENT
+
 # When true, selected non-secret but environment-specific fields are exported as
 # Ansible variable references (same naming scheme as secrets_as_variables).
 # Defaults to true whenever export_related_objects is enabled.

--- a/roles/filetree_create/defaults/main.yml
+++ b/roles/filetree_create/defaults/main.yml
@@ -66,11 +66,12 @@ hub_configuration_filetree_create_secure_logging: "{{ aap_configuration_secure_l
 secrets_as_variables: true
 secrets_as_variables_prefix: "vaulted"
 
-# Controller settings keys exported even when null or an empty list (defaults omitted
-# from settings/changed/ and filtered as empty by the export template).
-settings_export_include_empty:
-  - AWX_ANSIBLE_CALLBACK_PLUGINS
-  - DEFAULT_EXECUTION_ENVIRONMENT
+# Export defaults for controller settings omitted from settings/changed/ or filtered as
+# empty. Keys defined here are always exported (see controller_settings.j2).
+template_overrides_global:
+  controller_setting:
+    AWX_ANSIBLE_CALLBACK_PLUGINS: []
+    DEFAULT_EXECUTION_ENVIRONMENT: ""
 
 # When true, selected non-secret but environment-specific fields are exported as
 # Ansible variable references (same naming scheme as secrets_as_variables).

--- a/roles/filetree_create/meta/argument_specs.yml
+++ b/roles/filetree_create/meta/argument_specs.yml
@@ -35,15 +35,6 @@ argument_specs:
         required: false
         type: bool
         description: When true, embed infra.aap_configuration inline object roles (users/teams) on inventories, projects, job templates, workflow job templates, credentials, and instance groups.
-      settings_export_include_empty:
-        default:
-          - AWX_ANSIBLE_CALLBACK_PLUGINS
-          - DEFAULT_EXECUTION_ENVIRONMENT
-        required: false
-        type: list
-        elements: str
-        description: Controller settings keys exported even when null or an empty list.
-
       # Async variables
       controller_configuration_async_retries:
         default: 30

--- a/roles/filetree_create/meta/argument_specs.yml
+++ b/roles/filetree_create/meta/argument_specs.yml
@@ -35,6 +35,14 @@ argument_specs:
         required: false
         type: bool
         description: When true, embed infra.aap_configuration inline object roles (users/teams) on inventories, projects, job templates, workflow job templates, credentials, and instance groups.
+      settings_export_include_empty:
+        default:
+          - AWX_ANSIBLE_CALLBACK_PLUGINS
+          - DEFAULT_EXECUTION_ENVIRONMENT
+        required: false
+        type: list
+        elements: str
+        description: Controller settings keys exported even when null or an empty list.
 
       # Async variables
       controller_configuration_async_retries:

--- a/roles/filetree_create/tasks/controller_settings.yml
+++ b/roles/filetree_create/tasks/controller_settings.yml
@@ -8,17 +8,6 @@
     settings_export_from_changed: true
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
-- name: "Supplement controller settings that must export even when null or empty"
-  ansible.builtin.set_fact:
-    all_settings:
-      - "{{ all_settings[0] | combine(__settings_export_include_empty_values) }}"
-  vars:
-    __full_settings: "{{ query('ansible.platform.gateway_api', 'api/controller/v2/settings/all/',
-                              host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
-                              return_all=true, max_objects=query_controller_api_max_objects)[0] }}"
-    __settings_export_include_empty_values: "{{ __full_settings | dict2items | selectattr('key', 'in', settings_export_include_empty) | items2dict }}"
-  no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
-
 - name: "Create the output directory for controller_settings in {{ output_path }}"
   ansible.builtin.file:
     path: "{{ output_path }}"

--- a/roles/filetree_create/tasks/controller_settings.yml
+++ b/roles/filetree_create/tasks/controller_settings.yml
@@ -8,6 +8,17 @@
     settings_export_from_changed: true
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
+- name: "Supplement controller settings that must export even when null or empty"
+  ansible.builtin.set_fact:
+    all_settings:
+      - "{{ all_settings[0] | combine(__settings_export_include_empty_values) }}"
+  vars:
+    __full_settings: "{{ query('ansible.platform.gateway_api', 'api/controller/v2/settings/all/',
+                              host=aap_hostname, oauth_token=__filetree_create_oauth_token, verify_ssl=aap_validate_certs,
+                              return_all=true, max_objects=query_controller_api_max_objects)[0] }}"
+    __settings_export_include_empty_values: "{{ __full_settings | dict2items | selectattr('key', 'in', settings_export_include_empty) | items2dict }}"
+  no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
+
 - name: "Create the output directory for controller_settings in {{ output_path }}"
   ansible.builtin.file:
     path: "{{ output_path }}"

--- a/roles/filetree_create/templates/controller_settings.j2
+++ b/roles/filetree_create/templates/controller_settings.j2
@@ -6,8 +6,15 @@ controller_settings:
 {% if not (settings_export_from_changed | default(false)) %}
 {%   set __empty_values = __empty_values + [''] %}
 {% endif %}
-{% set __settings_always_export = settings_export_include_empty | default([]) %}
-{% for key,value in all_settings[0].items() if (value not in __empty_values) or (key in __settings_always_export) %}
+{% set __global_settings = template_overrides_global.controller_setting | default({}) %}
+{% set __resource_settings = template_overrides_resources.controller_setting | default({}) %}
+{% set __api_settings = all_settings[0] | default({}) %}
+{% set __all_keys = (__api_settings.keys() | list + __global_settings.keys() | list + __resource_settings.keys() | list) | unique %}
+{% for key in __all_keys %}
+{%   set value = __resource_settings[key] | default(__global_settings[key]) | default(__api_settings[key]) %}
+{%   if (value not in __empty_values)
+        or __global_settings[key] is defined
+        or __resource_settings[key] is defined %}
 {%   if value is mapping or value | type_debug == "list" %}
 {{ key | indent(width=4, first=True) }}:
 {{ value | to_nice_yaml(indent=2, sort_keys=false) | indent(width=6, first=True) }}
@@ -19,5 +26,6 @@ controller_settings:
 {%     endif %}
 {%   else %}
 {{ key | indent(width=4, first=True) }}: {{ yamlval.render_scalar(value) }}
+{%   endif %}
 {%   endif %}
 {% endfor %}

--- a/roles/filetree_create/templates/controller_settings.j2
+++ b/roles/filetree_create/templates/controller_settings.j2
@@ -6,7 +6,8 @@ controller_settings:
 {% if not (settings_export_from_changed | default(false)) %}
 {%   set __empty_values = __empty_values + [''] %}
 {% endif %}
-{% for key,value in all_settings[0].items() if value not in __empty_values %}
+{% set __settings_always_export = settings_export_include_empty | default([]) %}
+{% for key,value in all_settings[0].items() if (value not in __empty_values) or (key in __settings_always_export) %}
 {%   if value is mapping or value | type_debug == "list" %}
 {{ key | indent(width=4, first=True) }}:
 {{ value | to_nice_yaml(indent=2, sort_keys=false) | indent(width=6, first=True) }}


### PR DESCRIPTION
## Summary
- Export `AWX_ANSIBLE_CALLBACK_PLUGINS` and `DEFAULT_EXECUTION_ENVIRONMENT` in `controller_settings` even when the API value is an empty list or `null`
- Supplement from `settings/all` so keys omitted from `settings/changed` are still present
- Add `settings_export_include_empty` (defaults to the two keys above)

Closes #342.

## Test plan
- [x] Template render with `null` / `[]` values exports both keys
- [ ] Export `controller_settings` from AAP and confirm both keys appear when cleared


Made with [Cursor](https://cursor.com)