### PR TITLE
fix(filetree_create): honor secrets_as_variables for gateway_settings

### DIFF
--- a/changelogs/fragments/issue340-gateway-settings-secrets.yml
+++ b/changelogs/fragments/issue340-gateway-settings-secrets.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - 'filetree_create - Honor ``secrets_as_variables`` when exporting ``gateway_settings`` password fields. Fixes #340.'

--- a/roles/filetree_create/templates/gateway_settings.j2
+++ b/roles/filetree_create/templates/gateway_settings.j2
@@ -6,13 +6,16 @@ gateway_settings:
 {%   set __empty_values = __empty_values + [''] %}
 {% endif %}
 {% for key,value in all_settings[0].items() if value not in __empty_values %}
+{%   set __gs_secret = (value is string) and ('$encrypted$' in value) and (secrets_as_variables | bool) %}
 {%   if value is mapping or value | type_debug == "list" %}
 {{ key | indent(width=2, first=true) }}:
 {{ value | to_nice_yaml(indent=2, sort_keys=false) | indent(width=4, first=true) }}
 {%   elif key == "jwt_public_key" %}{#
 {{ key | indent(width=2, first=true) }}: |-
 {{ value | indent(width=4, first=true) }}
-#}{%   else %}
+#}{%   elif __gs_secret %}
+{{ key | indent(width=2, first=true) }}: "{{ value | infra.aap_configuration_extended.filetree_as_var('gateway_settings', 'settings', key, true, secrets_as_variables_prefix) }}"
+{%   else %}
 {{ key | indent(width=2, first=true) }}: {{ yamlval.render_scalar(value) }}
 {%   endif %}
 {% endfor %}


### PR DESCRIPTION
## Summary
- Apply `secrets_as_variables` to `gateway_settings` export so `$encrypted$` values become `vaulted_*` variable references (same pattern as credentials and notification templates)
- Uses `filetree_as_var` with object type `gateway_settings` and field name per setting key

Fixes #340.

## Test plan
- [x] Template render: `REDHAT_PASSWORD: "$encrypted$"` exports `{{ vaulted_gateway_settings_settings_redhat_password }}`
- [ ] Export `gateway_settings` from AAP with `secrets_as_variables: true` and confirm password fields use vaulted placeholders


Made with [Cursor](https://cursor.com)