### PR TITLE
fix(filetree_create): controller_settings null EE and AWX_TASK_ENV

### DIFF
--- a/changelogs/fragments/issue342-controller-settings-followup.yml
+++ b/changelogs/fragments/issue342-controller-settings-followup.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - 'filetree_create - Export ``DEFAULT_EXECUTION_ENVIRONMENT`` as ``null`` and include ``AWX_TASK_ENV`` in controller_settings defaults. Fixes #342 follow-up.'

--- a/roles/filetree_create/defaults/main.yml
+++ b/roles/filetree_create/defaults/main.yml
@@ -71,7 +71,8 @@ secrets_as_variables_prefix: "vaulted"
 template_overrides_global:
   controller_setting:
     AWX_ANSIBLE_CALLBACK_PLUGINS: []
-    DEFAULT_EXECUTION_ENVIRONMENT: ""
+    AWX_TASK_ENV: {}
+    DEFAULT_EXECUTION_ENVIRONMENT: null
 
 # When true, selected non-secret but environment-specific fields are exported as
 # Ansible variable references (same naming scheme as secrets_as_variables).

--- a/roles/filetree_create/templates/controller_settings.j2
+++ b/roles/filetree_create/templates/controller_settings.j2
@@ -24,6 +24,8 @@ controller_settings:
 {%     else %}
 {{ key | indent(width=4, first=True) }}: '{{ (value | string) | replace("'", "''") }}'
 {%     endif %}
+{%   elif value is none %}
+{{ key | indent(width=4, first=True) }}: null
 {%   else %}
 {{ key | indent(width=4, first=True) }}: {{ yamlval.render_scalar(value) }}
 {%   endif %}


### PR DESCRIPTION
## Summary
- Export `DEFAULT_EXECUTION_ENVIRONMENT` as YAML `null` (not `""`) for idempotent apply
- Add `AWX_TASK_ENV: {}` to `template_overrides_global.controller_setting` defaults
- Render explicit `null` in `controller_settings.j2` before `yamlval.render_scalar` (which maps `none` to `""`)

Fixes #342 follow-up per @myllynen feedback.

## Test plan
- [x] Template render exports `DEFAULT_EXECUTION_ENVIRONMENT: null` and `AWX_TASK_ENV: {}`
- [ ] Export + import `controller_settings` roundtrip on AAP


Made with [Cursor](https://cursor.com)