### PR TITLE
fix(filetree_create): skip duplicate roles with inline object export

### DIFF
--- a/changelogs/fragments/issue343-inline-object-roles-dedup.yml
+++ b/changelogs/fragments/issue343-inline-object-roles-dedup.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - 'filetree_create - Skip duplicate controller_roles export for inline-object types when ``export_inline_object_roles`` is enabled. Fixes #343.'

--- a/roles/filetree_create/defaults/main.yml
+++ b/roles/filetree_create/defaults/main.yml
@@ -56,6 +56,15 @@ export_related_objects: false
 # on inventories, projects, job templates, workflow job templates, credentials,
 # and instance groups. Default false keeps the separate controller_roles export.
 export_inline_object_roles: false
+# Controller API resource_type values omitted from controller_roles export when
+# export_inline_object_roles is true (roles are embedded on the object YAML).
+inline_object_role_resource_types:
+  - inventory
+  - project
+  - job_template
+  - workflow_job_template
+  - credential
+  - instance_group
 skip_inventory_sources: false
 skip_inventory_hosts: false
 skip_inventory_groups: false

--- a/roles/filetree_create/templates/controller_team_roles.j2
+++ b/roles/filetree_create/templates/controller_team_roles.j2
@@ -4,33 +4,34 @@ controller_roles:
 {% endif %}
 {% for role in object_roles %}
 {%   set __role_entry = (role | dict2items)[0] %}
-{%   set __resource_type = __role_entry.value.resource_type | default('') %}
+{%   set __role_value = __role_entry.value %}
+{%   set __resource_type = __role_value.resource_type | default('') %}
 {%   if not ((export_inline_object_roles | default(false) | bool) and (__resource_type in inline_object_role_resource_types)) %}
-{%   if __role_entry.value.resource_type is defined %}
+{%   if __resource_type is defined and __resource_type != '' %}
   - team: "{{ team_name }}"
-{%   if (role|dict2items)[0].value.resource_names | length > 0 %}
-{%     if (role|dict2items)[0].value.resource_type is match('organization') %}
+{%   if __role_value.resource_names | length > 0 %}
+{%     if __resource_type is match('organization') %}
     organizations:
-{%     elif (role|dict2items)[0].value.resource_type is match('team') %}
+{%     elif __resource_type is match('team') %}
     target_teams:
-{%     elif (role|dict2items)[0].value.resource_type is match('job_template') %}
+{%     elif __resource_type is match('job_template') %}
     job_templates:
-{%     elif (role|dict2items)[0].value.resource_type is match('inventory') %}
+{%     elif __resource_type is match('inventory') %}
     inventories:
-{%     elif (role|dict2items)[0].value.resource_type is match('workflow_job_template') %}
+{%     elif __resource_type is match('workflow_job_template') %}
     workflows:
-{%     elif (role|dict2items)[0].value.resource_type is match('project') %}
+{%     elif __resource_type is match('project') %}
     projects:
-{%     elif (role|dict2items)[0].value.resource_type is match('credential') %}
+{%     elif __resource_type is match('credential') %}
     credentials:
-{%     elif (role|dict2items)[0].value.resource_type is match('instance_group') %}
+{%     elif __resource_type is match('instance_group') %}
     instance_groups:
 {%     endif %}
-{%     for object_name in (role|dict2items)[0].value.resource_names %}
+{%     for object_name in __role_value.resource_names %}
       - "{{ object_name }}"
 {%     endfor %}
 {%   endif %}
-    role: "{% if (role|dict2items)[0].key | lower == 'approve' %}approval{% else %}{{ (role|dict2items)[0].key | lower | regex_replace(' ', '_') }}{% endif %}"
+    role: "{% if __role_entry.key | lower == 'approve' %}approval{% else %}{{ __role_entry.key | lower | regex_replace(' ', '_') }}{% endif %}"
 {%   endif %}
 {%   endif %}
 {% endfor %}

--- a/roles/filetree_create/templates/controller_team_roles.j2
+++ b/roles/filetree_create/templates/controller_team_roles.j2
@@ -7,32 +7,32 @@ controller_roles:
 {%   set __role_value = __role_entry.value %}
 {%   set __resource_type = __role_value.resource_type | default('') %}
 {%   if not ((export_inline_object_roles | default(false) | bool) and (__resource_type in inline_object_role_resource_types)) %}
-{%   if __resource_type is defined and __resource_type != '' %}
+{%     if __resource_type is defined and __resource_type != '' %}
   - team: "{{ team_name }}"
-{%   if __role_value.resource_names | length > 0 %}
-{%     if __resource_type is match('organization') %}
+{%       if __role_value.resource_names | length > 0 %}
+{%         if __resource_type is match('organization') %}
     organizations:
-{%     elif __resource_type is match('team') %}
+{%         elif __resource_type is match('team') %}
     target_teams:
-{%     elif __resource_type is match('job_template') %}
+{%         elif __resource_type is match('job_template') %}
     job_templates:
-{%     elif __resource_type is match('inventory') %}
+{%         elif __resource_type is match('inventory') %}
     inventories:
-{%     elif __resource_type is match('workflow_job_template') %}
+{%         elif __resource_type is match('workflow_job_template') %}
     workflows:
-{%     elif __resource_type is match('project') %}
+{%         elif __resource_type is match('project') %}
     projects:
-{%     elif __resource_type is match('credential') %}
+{%         elif __resource_type is match('credential') %}
     credentials:
-{%     elif __resource_type is match('instance_group') %}
+{%         elif __resource_type is match('instance_group') %}
     instance_groups:
-{%     endif %}
-{%     for object_name in __role_value.resource_names %}
+{%         endif %}
+{%         for object_name in __role_value.resource_names %}
       - "{{ object_name }}"
-{%     endfor %}
-{%   endif %}
+{%         endfor %}
+{%       endif %}
     role: "{% if __role_entry.key | lower == 'approve' %}approval{% else %}{{ __role_entry.key | lower | regex_replace(' ', '_') }}{% endif %}"
-{%   endif %}
+{%     endif %}
 {%   endif %}
 {% endfor %}
 {% if last_team_role | default(true) | bool %}

--- a/roles/filetree_create/templates/controller_team_roles.j2
+++ b/roles/filetree_create/templates/controller_team_roles.j2
@@ -3,7 +3,10 @@
 controller_roles:
 {% endif %}
 {% for role in object_roles %}
-{%   if (role|dict2items)[0].value.resource_type is defined %}
+{%   set __role_entry = (role | dict2items)[0] %}
+{%   set __resource_type = __role_entry.value.resource_type | default('') %}
+{%   if not ((export_inline_object_roles | default(false) | bool) and (__resource_type in inline_object_role_resource_types)) %}
+{%   if __role_entry.value.resource_type is defined %}
   - team: "{{ team_name }}"
 {%   if (role|dict2items)[0].value.resource_names | length > 0 %}
 {%     if (role|dict2items)[0].value.resource_type is match('organization') %}
@@ -28,6 +31,7 @@ controller_roles:
 {%     endfor %}
 {%   endif %}
     role: "{% if (role|dict2items)[0].key | lower == 'approve' %}approval{% else %}{{ (role|dict2items)[0].key | lower | regex_replace(' ', '_') }}{% endif %}"
+{%   endif %}
 {%   endif %}
 {% endfor %}
 {% if last_team_role | default(true) | bool %}

--- a/roles/filetree_create/templates/controller_user_roles.j2
+++ b/roles/filetree_create/templates/controller_user_roles.j2
@@ -7,32 +7,32 @@ controller_roles:
 {%   set __role_value = __role_entry.value %}
 {%   set __resource_type = __role_value.resource_type | default('') %}
 {%   if not ((export_inline_object_roles | default(false) | bool) and (__resource_type in inline_object_role_resource_types)) %}
-{%   if __resource_type is defined and __resource_type != '' %}
+{%     if __resource_type is defined and __resource_type != '' %}
   - user: "{{ username }}"
-{%   if __role_value.resource_names | length > 0 %}
-{%     if __resource_type is match('organization') %}
+{%       if __role_value.resource_names | length > 0 %}
+{%         if __resource_type is match('organization') %}
     organizations:
-{%     elif __resource_type is match('team') %}
+{%         elif __resource_type is match('team') %}
     target_teams:
-{%     elif __resource_type is match('job_template') %}
+{%         elif __resource_type is match('job_template') %}
     job_templates:
-{%     elif __resource_type is match('inventory') %}
+{%         elif __resource_type is match('inventory') %}
     inventories:
-{%     elif __resource_type is match('workflow_job_template') %}
+{%         elif __resource_type is match('workflow_job_template') %}
     workflows:
-{%     elif __resource_type is match('project') %}
+{%         elif __resource_type is match('project') %}
     projects:
-{%     elif __resource_type is match('credential') %}
+{%         elif __resource_type is match('credential') %}
     credentials:
-{%     elif __resource_type is match('instance_group') %}
+{%         elif __resource_type is match('instance_group') %}
     instance_groups:
-{%     endif %}
-{%     for object_name in __role_value.resource_names %}
+{%         endif %}
+{%         for object_name in __role_value.resource_names %}
       - "{{ object_name }}"
-{%     endfor %}
-{%   endif %}
+{%         endfor %}
+{%       endif %}
     role: "{% if __role_entry.key | lower == 'approve' %}approval{% else %}{{ __role_entry.key | lower | regex_replace(' ', '_') }}{% endif %}"
-{%   endif %}
+{%     endif %}
 {%   endif %}
 {% endfor %}
 {% if last_user_role | default(true) | bool %}

--- a/roles/filetree_create/templates/controller_user_roles.j2
+++ b/roles/filetree_create/templates/controller_user_roles.j2
@@ -3,7 +3,10 @@
 controller_roles:
 {% endif %}
 {% for role in object_roles %}
-{%   if (role|dict2items)[0].value.resource_type is defined %}
+{%   set __role_entry = (role | dict2items)[0] %}
+{%   set __resource_type = __role_entry.value.resource_type | default('') %}
+{%   if not ((export_inline_object_roles | default(false) | bool) and (__resource_type in inline_object_role_resource_types)) %}
+{%   if __role_entry.value.resource_type is defined %}
   - user: "{{ username }}"
 {%   if (role|dict2items)[0].value.resource_names | length > 0 %}
 {%     if (role|dict2items)[0].value.resource_type is match('organization') %}
@@ -26,6 +29,7 @@ controller_roles:
 {%     endfor %}
 {%   endif %}
     role: "{% if (role|dict2items)[0].key | lower == 'approve' %}approval{% else %}{{ (role|dict2items)[0].key | lower | regex_replace(' ', '_') }}{% endif %}"
+{%   endif %}
 {%   endif %}
 {% endfor %}
 {% if last_user_role | default(true) | bool %}

--- a/roles/filetree_create/templates/controller_user_roles.j2
+++ b/roles/filetree_create/templates/controller_user_roles.j2
@@ -4,31 +4,34 @@ controller_roles:
 {% endif %}
 {% for role in object_roles %}
 {%   set __role_entry = (role | dict2items)[0] %}
-{%   set __resource_type = __role_entry.value.resource_type | default('') %}
+{%   set __role_value = __role_entry.value %}
+{%   set __resource_type = __role_value.resource_type | default('') %}
 {%   if not ((export_inline_object_roles | default(false) | bool) and (__resource_type in inline_object_role_resource_types)) %}
-{%   if __role_entry.value.resource_type is defined %}
+{%   if __resource_type is defined and __resource_type != '' %}
   - user: "{{ username }}"
-{%   if (role|dict2items)[0].value.resource_names | length > 0 %}
-{%     if (role|dict2items)[0].value.resource_type is match('organization') %}
+{%   if __role_value.resource_names | length > 0 %}
+{%     if __resource_type is match('organization') %}
     organizations:
-{%     elif (role|dict2items)[0].value.resource_type is match('team') %}
+{%     elif __resource_type is match('team') %}
     target_teams:
-{%     elif (role|dict2items)[0].value.resource_type is match('job_template') %}
+{%     elif __resource_type is match('job_template') %}
     job_templates:
-{%     elif (role|dict2items)[0].value.resource_type is match('inventory') %}
+{%     elif __resource_type is match('inventory') %}
     inventories:
-{%     elif (role|dict2items)[0].value.resource_type is match('workflow_job_template') %}
+{%     elif __resource_type is match('workflow_job_template') %}
     workflows:
-{%     elif (role|dict2items)[0].value.resource_type is match('project') %}
+{%     elif __resource_type is match('project') %}
     projects:
-{%     elif (role|dict2items)[0].value.resource_type is match('credential') %}
+{%     elif __resource_type is match('credential') %}
     credentials:
+{%     elif __resource_type is match('instance_group') %}
+    instance_groups:
 {%     endif %}
-{%     for object_name in (role|dict2items)[0].value.resource_names %}
+{%     for object_name in __role_value.resource_names %}
       - "{{ object_name }}"
 {%     endfor %}
 {%   endif %}
-    role: "{% if (role|dict2items)[0].key | lower == 'approve' %}approval{% else %}{{ (role|dict2items)[0].key | lower | regex_replace(' ', '_') }}{% endif %}"
+    role: "{% if __role_entry.key | lower == 'approve' %}approval{% else %}{{ __role_entry.key | lower | regex_replace(' ', '_') }}{% endif %}"
 {%   endif %}
 {%   endif %}
 {% endfor %}


### PR DESCRIPTION
## Summary
- When `export_inline_object_roles` is true, skip `controller_roles` entries for resource types that already embed inline `roles` on the object YAML
- Configurable via `inline_object_role_resource_types` (inventory, project, job_template, workflow_job_template, credential, instance_group)

Fixes #343.

## Test plan
- [ ] Export with `export_inline_object_roles: true` and confirm inline `roles` on objects without duplicate user/team role files for those types
- [ ] Export with `export_inline_object_roles: false` and confirm `controller_roles` still includes all resource types


Made with [Cursor](https://cursor.com)