### PR TITLE
fix(changelog): quote fragment entry that YAML parsed as a dict

### DIFF
--- a/changelogs/fragments/aap_config_validate_improvements.yml
+++ b/changelogs/fragments/aap_config_validate_improvements.yml
@@ -1,6 +1,8 @@
 ---
 minor_changes:
-  - aap-config-validate - Accept Ansible-quoted scalars (``"0"``, ``"false"``, ``"{}"``), treat empty strings as unset, and skip extra required fields when ``state: absent``.
+  - >-
+    aap-config-validate - Accept Ansible-quoted scalars (``"0"``, ``"false"``, ``"{}"``),
+    treat empty strings as unset, and skip extra required fields when ``state: absent``.
   - aap-config-validate - Report the source YAML file on each issue; deep-merge dicts across files; match nested ``exclude_dirs`` paths such as ``tests/fixtures``.
   - aap-config-validate - Recognise filetree and template aliases (``gateway_organizations``, ``controller_user_accounts``, ``controller_templates_all``, …) and merge env-suffixed vars in ``auto`` mode when those suffixes are present.
 bugfixes:

--- a/changelogs/fragments/fix-changelog-fragment-yaml-lint.yml
+++ b/changelogs/fragments/fix-changelog-fragment-yaml-lint.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix changelog fragment YAML parsing for ``aap_config_validate_improvements`` so automated release lint passes.


### PR DESCRIPTION
## Summary

- Fix `changelogs/fragments/aap_config_validate_improvements.yml` so the first `minor_changes` entry is a string, not a YAML mapping.
- The text ``state: absent`` contained a colon that YAML interpreted as `key: value`, which fails `antsibull-changelog lint` during automated release.

## Why pre-commit did not block the original fragment

Yes, we have a **Validate Changelog** pre-commit hook. It does two things:

1. **Weaker check** on *new* fragment files in the diff (`is_valid_changelog_format`) — verifies section names and that values are lists, but **does not** verify list items are strings.
2. **`antsibull-changelog lint`** on the whole tree — this *would* catch this bug, and it passed on this PR.

The bad fragment landed in #346 before the stricter release path was exercised; release is the first place that runs `antsibull-changelog release` over all fragments together.

## Test plan

- [ ] Merge PR
- [ ] Trigger **Release - Automated** via workflow_dispatch
- [ ] Confirm **Generate changelog** completes


Made with [Cursor](https://cursor.com)