### PR TITLE
fix(filetree_read): change inventories import order

### DIFF
--- a/changelogs/fragments/fix-filetree-read-order-inventories.yml
+++ b/changelogs/fragments/fix-filetree-read-order-inventories.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - filetree_read - Change inventories order so that constructed inventories are imported last

--- a/roles/filetree_read/tasks/controller_inventories.yml
+++ b/roles/filetree_read/tasks/controller_inventories.yml
@@ -24,6 +24,13 @@
   ansible.builtin.set_fact:
     controller_inventories: >-
       {{
+        (__all_inventories | rejectattr('kind', 'defined') +
+         __all_inventories | selectattr('kind', 'defined') | rejectattr('kind', 'equalto', 'constructed')) +
+        (__all_inventories | selectattr('kind', 'defined') | selectattr('kind', 'equalto', 'constructed'))
+      }}
+  vars:
+    __all_inventories: >-
+      {{
         __contents_filetree_controller_inventories.results |
         rejectattr('ansible_facts.controller_inventories', 'undefined') |
         map(attribute='ansible_facts.controller_inventories') |


### PR DESCRIPTION
Change inventories order in tasks/controller_inventories.yml so that constructed inventories are imported last, when other inventories they may depend on are already imported.

<!--- markdownlint-disable -->
# What does this PR do?
Changes inventories order in filtetree_read/tasks/controller_inventories.yml so that constructed inventories are imported last, when other inventories they may depend on are already imported.

## How should this be tested?
- Create a new simple inventory and a constructed inventory using the first as an input inventory.
- Export inventories using infra.aap_configuration_extended.filetree_create.
- Delete the inventories created in the first step.
- Import the inventories back using infra.aap_configuration_extended.filetree_read and infra.aap_configuration.dispatch.
- Inventories from step 1 must be imported without errors.

## Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #[number]

## Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
